### PR TITLE
Chore/Set timestampz as default datetime type

### DIFF
--- a/config/initializers/postgres.rb
+++ b/config/initializers/postgres.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_record/connection_adapters/postgresql_adapter"
+
+# Forces Rails to use +postgresql+ +timestampz+ datetime type. This type keeps tracks
+# datetime values with a timezone, which makes easier to handle them when converting
+# times to different time zones.
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type = :timestampz

--- a/config/initializers/postgres.rb
+++ b/config/initializers/postgres.rb
@@ -2,7 +2,16 @@
 
 require "active_record/connection_adapters/postgresql_adapter"
 
-# Forces Rails to use +postgresql+ +timestampz+ datetime type. This type keeps tracks
-# datetime values with a timezone, which makes easier to handle them when converting
-# times to different time zones.
+# Adds a new type +timestampz+ to the set of +postgresql+ adapter kinds
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      NATIVE_DATABASE_TYPES.merge!(timestampz: { name: "timestamptz" })
+    end
+  end
+end
+
+# Sets +Rails+ to use +timestampz+ instead of +datetime+ in the backend to store
+# datetime values. By tracking the time zone we do not need to take care of converting
+# times to a common time zone before persisting.
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type = :timestampz

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,8 +17,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_15_140651) do
   create_table "weddings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.date "date"
     t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.timestamptz "created_at", precision: 6, null: false
+    t.timestamptz "updated_at", precision: 6, null: false
   end
 
 end


### PR DESCRIPTION
- Configures Rails application to track `timezone` in datetime values.