### PR TITLE
chore: dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     commit-message:
       # Prefix all commit messages with "npm: "
       prefix: "bundle"
+    groups:
+      # Rails Project Dependencies
+      rails:
+        exclude-patterns:
+          - "rubocop*"
+      # Rails Linter Dependencies
+      ruby-linter:
+        patterns:
+          - "rubocop*"
 
   # NPM Package Configuration
   - package-ecosystem: "npm"
@@ -25,3 +34,14 @@ updates:
     commit-message:
       # Prefix all commit messages with "npm: "
       prefix: "npm"
+    groups:
+      # Javascript Dependencies
+      js:
+        exclude-patterns:
+          - "postcss*"
+          - "autoprefixer"
+      # CSS Bundler Dependencies
+      css-bundling:
+        patterns:
+          - "postcss*"
+          - "autoprefixer"

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# CSS Bundling
+gem "cssbundling-rails", "~> 1.2"
+
 # A framework for building reusable, testable & encapsulated view components in Ruby on Rails.
 # https://github.com/viewcomponent/view_component
 gem "view_component"
@@ -99,5 +102,3 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
-
-gem "cssbundling-rails", "~> 1.2"


### PR DESCRIPTION
Update `dependabot` configuration to group multiple dependency updates in single PRs. This reduces the amount of open PRs, making easier to manage them.