### PR TITLE
feature: icon component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,6 @@ Minitest/RefutePredicate:
 
 Metrics/BlockLength:
   Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "haml-rails", "~> 2.0"
 # Fixtures replacement with a straightforward definition syntax
 gem "factory_bot_rails"
 
+# Gem for SVG import & styling via CSS
+gem "inline_svg", "~> 1.9.0"
+
 group :development, :test do
   # powerful component browser and preview system with an integrated documentation engine
   gem "lookbook", ">= 2.0.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,9 @@ GEM
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
+    inline_svg (1.9.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
     io-console (0.6.0)
     irb (1.7.4)
       reline (>= 0.3.6)
@@ -310,6 +313,7 @@ DEPENDENCIES
   faker
   haml-rails (~> 2.0)
   importmap-rails
+  inline_svg (~> 1.9.0)
   jbuilder
   lookbook (>= 2.0.5)
   pg (~> 1.5)

--- a/app/assets/images/icons/arrow-left.svg
+++ b/app/assets/images/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12h-15m0 0l6.75 6.75M4.5 12l6.75-6.75" />
+</svg>

--- a/app/components/common/icon_component.rb
+++ b/app/components/common/icon_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Renders SVG icons and provides additional styling customization options
+module Common
+  class IconComponent < ApplicationComponent
+    ICONS_ASSET_PATH = "icons/"
+
+    SIZES = {
+      xs: "xs",
+      sm: "sm",
+      base: "base",
+      lg: "lg",
+      xl: "xl"
+    }.freeze
+
+    attr_reader :icon, :size
+
+    def initialize(icon, size: :base, classes: nil, **system_arguments)
+      @icon = icon
+      @size = SIZES[size.to_sym]
+      super(classes:, **system_arguments)
+    end
+
+    def call = inline_svg_tag(svg_file, default_system_arguments)
+
+    def default_system_arguments
+      {
+        # https://github.com/jamesmartin/inline_svg#accessibility
+        aria: true,
+        aria_hidden: true,
+        title: icon,
+        desc: "#{icon} icon",
+        data: { size: },
+        class: <<-HTML
+          data-[size=xs]:w-[12px] data-[size=xs]:h-[12px]
+          data-[size=sm]:w-[16px] data-[size=sm]:h-[16px]
+          data-[size=base]:w-[20px] data-[size=base]:h-[20px]
+          data-[size=lg]:w-[22px] data-[size=lg]:h-[22px]
+          data-[size=xl]:w-[28px] data-[size=xl]:h-[28px]
+        HTML
+      }
+    end
+
+    def svg_file = @svg_file ||= "#{ICONS_ASSET_PATH}#{icon}.svg"
+  end
+end

--- a/app/helpers/component_helper.rb
+++ b/app/helpers/component_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ComponentHelper
+  def icon_component(icon:, size: :base, **system_arguments)
+    render(Common::IconComponent.new(icon, size:, **system_arguments))
+  end
+end

--- a/test/components/previews/common/icon_component_preview.rb
+++ b/test/components/previews/common/icon_component_preview.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# @label Icon Component
+class Common::IconComponentPreview < ViewComponent::Preview
+  # Icon Component
+  # --------------
+  # Renders an `.svg` component from the icon assets library available
+  # at `/assets/images/icons`. You can pass additional `HTML` parameters
+  # to customize your icons the way you want
+  #
+  # @param icon
+  # @param size select { choices: [xs, sm, base, lg, xl] }
+  def default(icon: :edit, size: :xl)
+    render Common::IconComponent.new(icon.to_sym, size:)
+  end
+
+  # Icons Collection
+  # ----------------
+  # List of all icons available in system. You can click on any icon to
+  # copy in your clipboard the helper method to render the selected icon.
+  #
+  # @param size select { choices: [xs, sm, base, lg, xl] }
+  def icons(size: :base)
+    render_with_template(locals: { size: })
+  end
+end

--- a/test/components/previews/common/icon_component_preview/icons.html.haml
+++ b/test/components/previews/common/icon_component_preview/icons.html.haml
@@ -1,0 +1,13 @@
+.grid.grid-cols-6.grid-flow-col.gap-4.p-4
+  - icons = Dir.glob("#{Rails.root}/app/assets/images/icons/**/*").map { |p| File.basename(p, ".*")  }
+  - size = local_assigns[:size]
+
+  - icons.sort.each do |icon|
+    - icon_helper = "icon_component(#{icon}, size: #{size})"
+
+    %button.group.p-4.flex.items-center.justify-center.rounded.cursor-pointer{ class: "hover:bg-gray-100 focus:bg-gray-200",
+                                                                               onclick: "navigator.clipboard.writeText('#{icon_helper}')" }
+      .flex.flex-col.gap-2.items-center.justify-center
+        = icon_component(icon:, size:)
+        %p.text-xs{ class: "group-focus:hidden" }= icon
+        %p.hidden.text-xs.font-bold{ class: "group-focus:block" } Copied to clipboard!


### PR DESCRIPTION
- Add new gem to render SVG as inline HTML element.
- Define new `Common::IconComponent` to render SVG images.
- Define a repository of SVG icons to render.
- Set up preview to render all SVG icons in application.