### PR TITLE
feature: add class name helper for components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,3 +64,6 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 8

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class ApplicationComponent < ViewComponent::Base
+  # Helper Concerns
+  include ClassNameHelper
+
   # Data attribute present in +HTML+ view component wrapper element
   VIEWCOMPONENT_ATTRIBUTE = "data-view-component"
-
-  # Stimulus Methods
 
   def initialize(classes: nil, **system_arguments)
     super
 
-    @classes = classes
+    @classes = class_names(default_classes, classes)
 
     system_arguments[VIEWCOMPONENT_ATTRIBUTE.to_sym] = true
 
     @content_tag_args = system_arguments
-    @content_tag_args = @content_tag_args.merge({ class: classes }) if classes.present?
+    @content_tag_args = @content_tag_args.merge({ class: @classes }) if classes.present?
   end
 
   protected

--- a/app/components/common/icon_component.rb
+++ b/app/components/common/icon_component.rb
@@ -15,13 +15,29 @@ module Common
 
     attr_reader :icon, :size
 
-    def initialize(icon, size: :base, classes: nil, **system_arguments)
+    def initialize(icon, size: :base, **system_arguments)
       @icon = icon
       @size = SIZES[size.to_sym]
-      super(classes:, **system_arguments)
+      super(**system_arguments)
     end
 
-    def call = inline_svg_tag(svg_file, default_system_arguments)
+    def call
+      inline_svg_tag(svg_file, default_system_arguments.merge(class: @classes))
+    end
+
+    protected
+
+    def default_classes
+      <<-HTML
+        data-[size=xs]:w-[12px] data-[size=xs]:h-[12px]
+        data-[size=sm]:w-[16px] data-[size=sm]:h-[16px]
+        data-[size=base]:w-[20px] data-[size=base]:h-[20px]
+        data-[size=lg]:w-[22px] data-[size=lg]:h-[22px]
+        data-[size=xl]:w-[28px] data-[size=xl]:h-[28px]
+      HTML
+    end
+
+    private
 
     def default_system_arguments
       {
@@ -30,14 +46,7 @@ module Common
         aria_hidden: true,
         title: icon,
         desc: "#{icon} icon",
-        data: { size: },
-        class: <<-HTML
-          data-[size=xs]:w-[12px] data-[size=xs]:h-[12px]
-          data-[size=sm]:w-[16px] data-[size=sm]:h-[16px]
-          data-[size=base]:w-[20px] data-[size=base]:h-[20px]
-          data-[size=lg]:w-[22px] data-[size=lg]:h-[22px]
-          data-[size=xl]:w-[28px] data-[size=xl]:h-[28px]
-        HTML
+        data: { size: }
       }
     end
 

--- a/app/components/concerns/class_name_helper.rb
+++ b/app/components/concerns/class_name_helper.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Inspired by https://github.com/JedWatson/classnames
+
+# Allow conditional class-name injection in components. This makes possible to
+# rewrite an original component class set by adding new classes and disabling
+# already existing classes in the component layout
+module ClassNameHelper
+  def class_names(*args) # rubocop:disable Metrics/AbcSize
+    classes = []
+
+    args.each do |class_arg|
+      next if class_arg.blank?
+
+      case class_arg
+      # class_arg = "px-4 py-5 bg-gray-100"
+      when String then classes += class_arg.split
+      # class_arg = { "px-4": true, "py-2": false }
+      when Hash
+        class_arg.each do |key, value|
+          next classes << key.to_s if value
+
+          classes.delete_if { _1 == key.to_s }
+        end
+      # class_arg = %w[px-4 py-2 bg-gray-100]
+      when Array then classes += class_arg
+      else
+        raise ArgumentError, "Argument '#{class_arg}' not valid as class argument for view component #{self.class.name}"
+      end
+    end
+
+    classes.compact.uniq.join(" ")
+  end
+end

--- a/test/components/concerns/class_name_helper_test.rb
+++ b/test/components/concerns/class_name_helper_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ClassNameHelperTest < ActiveSupport::TestCase
+  class SampleComponent < ApplicationComponent
+    include ClassNameHelper
+  end
+
+  attr_reader :component
+
+  setup do
+    @component = SampleComponent.new
+  end
+
+  test "#class_names returns a collection of CSS class names as a single string" do
+    sample_class_names = %w[class1 class2 class3 class4]
+
+    assert_equal "class1 class2 class3 class4", @component.class_names(*sample_class_names)
+  end
+
+  test "#class_names if CSS class names are passed as string argument,
+              includes given strings in returned string" do
+    sample_class_names = %w[class1 class2 class3 class4]
+
+    component_classes = @component.class_names(*sample_class_names)
+
+    assert_equal "class1 class2 class3 class4", component_classes
+  end
+
+  test "#class_names if CSS class names are passed as array argument,
+              includes given strings in returned string" do
+    sample_class_names = %w[class1 class2 class3 class4]
+
+    component_classes = @component.class_names(sample_class_names)
+
+    assert_equal "class1 class2 class3 class4", component_classes
+  end
+
+  test "#class_names if CSS class names are passed as hash argument with pairs class-name -> boolean,
+              and boolean is set to true
+              includes given strings in returned string" do
+    sample_class_names = { class1: true, class2: true, class3: true, class4: true }
+
+    component_classes = @component.class_names(sample_class_names)
+
+    assert_equal "class1 class2 class3 class4", component_classes
+  end
+
+  test "#class_names if CSS class names are passed as hash argument with pairs class-name -> boolean,
+              and boolean is set to false
+              does not include given strings in returned string" do
+    sample_class_names = { class1: false, class2: false, class3: false, class4: false }
+
+    component_classes = @component.class_names(sample_class_names)
+
+    assert_empty component_classes
+  end
+
+  test "#class_names if CSS class name is first passed as positive argument
+              and then passed as negative argument
+              do not include class in returned string" do
+    sample_class_names = { class1: false, class2: false, class3: false, class4: false }
+
+    component_classes = @component.class_names("class1", sample_class_names)
+
+    assert_empty component_classes
+  end
+
+  test "#class_names if CSS class name is first passed as positive argument
+              and then passed as negative argument
+              and then passed as positive argument
+              includes class in returned string" do
+    sample_class_names = { class1: false, class2: false, class3: false, class4: false }
+
+    component_classes = @component.class_names("class1", sample_class_names, "class1")
+
+    assert_equal "class1", component_classes
+  end
+end


### PR DESCRIPTION
Defines a new `class_names` helper for `ApplicationComponent`. Used by `ApplicationComponent` initializer to inject CSS classes in the component wrapper element.

The helper accepts CSS classes as a string of classes (separated by blank spaces), an array of classes, or a hash of classes; and returns a resulting string containing all given CSS classes to be passed to the `class` attribute of the wrapper container of the element being rendered.

In `hash` format, the object must be defined by pairs `class name -> boolean`. If set to true, the key (class name) will be added to the resulting string. If set to false, class will be removed from the resulting string. This method makes it possible to overwrite default CSS classes in components, making them more customizable.