### PR TITLE
Chore: TagAttributes object

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -4,28 +4,21 @@ class ApplicationComponent < ViewComponent::Base
   # Data attribute present in +HTML+ view component wrapper element
   VIEWCOMPONENT_ATTRIBUTE = "data-view-component"
 
-  # Helper Concerns
-  include ClassNameHelper
-
   def self.stimulus_identifier = name.underscore.gsub("/", "--").tr("_", "-")
 
   def self.generate_id(suffix = nil) = "#{stimulus_identifier}-#{suffix || SecureRandom.uuid}"
 
   delegate :generate_id, to: :class
 
-  attr_reader :classes, :id, :content_tag_args
+  attr_reader :id, :content_tag_args
 
-  def initialize(classes: nil, **system_arguments)
+  def initialize(**system_arguments)
     super
-
-    @classes = class_names(default_classes, classes)
-    @id = system_arguments[:id] || @id || generate_id
-
-    system_arguments[VIEWCOMPONENT_ATTRIBUTE.to_sym] = true
-
-    @content_tag_args = default_content_tag_arguments.merge(system_arguments)
-    @content_tag_args = @content_tag_args.merge({ id: @id }) if @id.present?
-    @content_tag_args = @content_tag_args.merge({ class: @classes }) if @classes.present?
+    @content_tag_args = ::Html::TagAttributes.build(
+      { class: default_classes },
+      default_content_tag_arguments,
+      system_arguments
+    ).to_h
   end
 
   def rendered_slots = instance_variable_get(:@__vc_set_slots)

--- a/app/lib/html/attribute.rb
+++ b/app/lib/html/attribute.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Html
+  CLASS_ATTRIBUTE = "class"
+  PREFIXED_ATTRIBUTES = %w[data aria].freeze
+
+  Attribute = Data.define(:name, :value) do
+    extend Helpers::ClassNameHelper, Helpers::AttributesHelper
+
+    class << self
+      def build(*hashes, name:)
+        value = if class_attribute?(name.to_s)
+                  class_names(*hashes.pluck(:class).compact)
+                elsif prefixed_attribute?(name.to_s)
+                  prefixed_attribute_value(*hashes, prefix: name)
+                else
+                  hashes.pluck(name.to_sym).compact.last
+                end
+
+        new(name: name.to_sym, value:)
+      end
+
+      private
+
+      def class_attribute?(name) = name == CLASS_ATTRIBUTE
+
+      def prefixed_attribute?(name) = PREFIXED_ATTRIBUTES.include?(name)
+    end
+
+    def to_h = { name => value }.symbolize_keys
+  end
+end

--- a/app/lib/html/helpers/attributes_helper.rb
+++ b/app/lib/html/helpers/attributes_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Html::Helpers::AttributesHelper
+  def prefixed_attribute_value(*hashes, prefix:) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+    return nil if hashes.empty?
+
+    prefix = prefix.to_s unless prefix.is_a?(String)
+
+    value = {}.tap do |result|
+      hashes.each do |hash|
+        next unless hash.is_a?(Hash)
+
+        prefixed_attribute_pairs(hash:, prefix:).each do |(key_sym, key_value)|
+          key = key_sym.to_s
+
+          if key == prefix
+            result.deep_merge!(key_value)
+          else
+            result[key.sub("#{prefix}-", "").to_sym] = key_value
+          end
+        end
+      end
+    end
+
+    value.empty? ? nil : value
+  end
+
+  private
+
+  def prefixed_attribute_pairs(hash:, prefix:)
+    hash.to_a.select do |(key_sym, value)|
+      key = key_sym.to_s
+
+      # data: { attribute: "value" }
+      (prefix == key && value.is_a?(Hash)) ||
+        # data-attribute: "value"
+        (key.start_with?(prefix) && prefix != key && !value.is_a?(Hash))
+    end
+  end
+end

--- a/app/lib/html/helpers/class_name_helper.rb
+++ b/app/lib/html/helpers/class_name_helper.rb
@@ -5,7 +5,7 @@
 # Allow conditional class-name injection in components. This makes possible to
 # rewrite an original component class set by adding new classes and disabling
 # already existing classes in the component layout
-module ClassNameHelper
+module Html::Helpers::ClassNameHelper
   def class_names(*args) # rubocop:disable Metrics/AbcSize
     classes = []
 

--- a/app/lib/html/tag_attributes.rb
+++ b/app/lib/html/tag_attributes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Html
+  TagAttributes = Data.define(:attributes) do
+    def self.build(*hashes)
+      attribute_names = hashes.flat_map(&:keys).uniq
+
+      new(attributes: attribute_names.map { |name| Attribute.build(*hashes, name:) })
+    end
+
+    def to_h = attributes.flat_map { _1.to_h.to_a }.to_h
+  end
+end

--- a/test/lib/html/attribute_test.rb
+++ b/test/lib/html/attribute_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Html::AttributeTest < ActiveSupport::TestCase
+  test ".build if attribute name is not present in hashes,
+              returns name attribute with nil value" do
+    attribute = Html::Attribute.build({}, name: :attribute)
+
+    assert_nil attribute.value
+  end
+
+  test ".build if attribute name is present in one hash,
+              returns name attribute with hash attribute value" do
+    attribute = Html::Attribute.build({ attribute: true }, name: :attribute)
+
+    assert attribute.value
+  end
+
+  test ".build if attribute name is present in multiple hash,
+              returns name attribute with attribute value in last hash" do
+    attribute = Html::Attribute.build({ attribute: true }, { attribute: false }, {}, name: :attribute)
+
+    assert_not attribute.value
+  end
+
+  test ".build if attribute name is class, return class attribute" do
+    attribute = Html::Attribute.build({ class: "px-1" }, { class: { "py-2": true } }, {}, name: :class)
+
+    assert_equal "px-1 py-2", attribute.value
+  end
+
+  test ".build if attribute name is data, return data prefixed attribute" do
+    attribute = Html::Attribute.build({ data: { foo: true } }, { "data-bar": true }, {}, name: :data)
+
+    assert_equal({ foo: true, bar: true }, attribute.value)
+  end
+
+  test ".build if attribute name is aria, return data prefixed attribute" do
+    attribute = Html::Attribute.build({ aria: { foo: true } }, { "aria-bar": true }, {}, name: :aria)
+
+    assert_equal({ foo: true, bar: true }, attribute.value)
+  end
+end

--- a/test/lib/html/helpers/attributes_helper_test.rb
+++ b/test/lib/html/helpers/attributes_helper_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Html::Helpers::AttributesHelperTest < ActiveSupport::TestCase
+  class TestComponent < ApplicationComponent
+    include Html::Helpers::AttributesHelper
+  end
+
+  attr_reader :component
+
+  def setup
+    @component = TestComponent.new
+  end
+
+  test ".prefixed_attribute_value returns hash merging all prefixed keys in hashes" do
+    hash1 = { "data-foo": "true", foo: "foo" }
+    hash2 = { "data-baz": "baz", bar: "bar", data: { bar: "false" } }
+
+    merged_data = component.prefixed_attribute_value(hash1, hash2, prefix: :data)
+
+    assert_equal({ foo: "true", bar: "false", baz: "baz" }, merged_data)
+  end
+
+  test ".prefixed_attribute_value if hashes has no prefix keys,
+              return nil attribute" do
+    assert_nil component.prefixed_attribute_value({ other: true }, prefix: :data)
+  end
+
+  test ".build_prefixed_attribute if hashes has prefix keys,
+              return hash prefixed key values" do
+    value = component.prefixed_attribute_value({ data: { foo: true } }, { "data-bar": false }, prefix: :data)
+
+    assert_equal({ foo: true, bar: false }, value)
+  end
+
+  test ".build_prefixed_attribute if hashes has prefix keys,
+              and a prefixed key is present within different hashes,
+              returned hash prefixed key last hash value" do
+    value = component.prefixed_attribute_value({ data: { bar: true } }, { "data-bar": false }, prefix: :data)
+
+    assert_equal({ bar: false }, value)
+  end
+end

--- a/test/lib/html/helpers/class_name_helper_test.rb
+++ b/test/lib/html/helpers/class_name_helper_test.rb
@@ -2,9 +2,9 @@
 
 require "test_helper"
 
-class ClassNameHelperTest < ActiveSupport::TestCase
+class Html::Helpers::ClassNameHelperTest < ActiveSupport::TestCase
   class SampleComponent < ApplicationComponent
-    include ClassNameHelper
+    include Html::Helpers::ClassNameHelper
   end
 
   attr_reader :component

--- a/test/lib/html/tag_attributes_test.rb
+++ b/test/lib/html/tag_attributes_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Html::AttributeTest < ActiveSupport::TestCase
+  test ".build returns hashes attributes" do
+    hashes = [
+      { class: "px-1", data: { foo: true }, id: "test1" },
+      { class: "py-2", data: { bar: true }, id: "test2", disabled: true }
+    ]
+
+    attributes = Html::TagAttributes.build(*hashes).to_h
+
+    assert_equal({ class: "px-1 py-2", data: { foo: true, bar: true }, id: "test2", disabled: true }, attributes)
+  end
+end


### PR DESCRIPTION
To concatenate multiple `system_arguments` in our `Components` this PR adds a new `TagAttributes` class responsible of handling `html` attributes from multiple hashes and merge them into a single one. The object handles special attributes such as `class` and prefixed attributes like `data` or `aria`.