### PR TITLE
feature: Modal Confirmation Component

### DIFF
--- a/app/components/common/date_picker_component.html.haml
+++ b/app/components/common/date_picker_component.html.haml
@@ -1,10 +1,14 @@
 %div{ content_tag_arguments }
   -# Calendar Header - Month Navigation
   .relative.w-full.inline-flex.items-center.justify-between.gap-3.text-xs
-    .inline-flex.items-center.justify-center.text-xs.gap-1
+    - navigation_button_options = { class: "inline-flex items-center justify-center text-xs gap-1" }
+
+    %div{ navigation_button_options }
       = icon_component(icon: "chevron-left", size: :xs, class: "cursor-pointer")
+
     %p.absolute.m-auto.left-0.right-0.w-fit.text-base.font-semibold.text-gray-900= l(calendar_month, format: "%B")
-    .inline-flex.items-center.justify-center.text-xs.gap-1
+
+    %div{ navigation_button_options }
       = icon_component(icon: "chevron-right", size: :xs, class: "cursor-pointer")
 
   -# Calendar Content - Month Days

--- a/app/components/common/date_picker_component.rb
+++ b/app/components/common/date_picker_component.rb
@@ -32,9 +32,9 @@ module Common
       attr_reader :base_url, :date, :date_url_parameter_name, :selected
 
       def initialize(
-        base_url: nil,
         date:,
-        date_url_parameter_name: "date", 
+        base_url: nil,
+        date_url_parameter_name: "date",
         selected: false,
         **system_arguments
       )
@@ -79,8 +79,6 @@ module Common
       end
     end
 
-    # Slots
-    # -----
     attr_reader :month,
                 :selected_date,
                 :url,

--- a/app/components/common/modal_component.rb
+++ b/app/components/common/modal_component.rb
@@ -8,7 +8,7 @@ module Common
 
       def call # rubocop:todo Metrics/AbcSize
         base_component(**content_tag_arguments) do
-          if header
+          if header?
             concat(
               base_component(class: "relative px-8 pt-6 pb-4") do
                 # Header title
@@ -23,7 +23,17 @@ module Common
               end
             )
           end
+
+          unless header?
+            concat(icon_button_component(icon: "x-mark",
+                                         size: :medium,
+                                         scheme: :invisible,
+                                         class: "absolute right-[32px] top-[15px]",
+                                         "data-action": "click->#{ModalComponent.stimulus_identifier}#close"))
+          end
+
           concat(content)
+
           concat(base_component(class: "px-8 pt-4 pb-6") { concat(footer) }) if footer
         end
       end

--- a/app/components/common/modal_confirmation_component.rb
+++ b/app/components/common/modal_confirmation_component.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Common
+  class ModalConfirmationComponent < ApplicationComponent
+    # Slots
+    # -----
+    renders_one :trigger
+
+    attr_reader :confirmation_header,
+                :confirmation_subheader,
+                :confirm_label,
+                :cancel_label,
+                :confirm_button_arguments,
+                :cancel_button_arguments
+
+    def initialize(
+      confirmation_header:,
+      confirm_label:,
+      cancel_label:,
+      confirmation_subheader: nil,
+      confirm_button_arguments: {},
+      cancel_button_arguments: {},
+      **system_arguments
+    )
+      super(**system_arguments)
+      @confirmation_header = confirmation_header
+      @confirmation_subheader = confirmation_subheader
+      @confirm_label = confirm_label
+      @cancel_label = cancel_label
+      @confirm_button_arguments = confirm_button_arguments
+      @cancel_button_arguments = cancel_button_arguments
+    end
+
+    def call
+      render Common::ModalComponent.new(**content_tag_arguments) do |modal|
+        if trigger?
+          modal.with_trigger do
+            concat(trigger)
+          end
+        end
+
+        modal.with_modal_content(class: "w-[600px]") do |content|
+          concat(
+            content_tag(:div, class: "px-8 pt-10 pb-6") do
+              title_component(title: confirmation_header, size: :small, class: "text-center") do |title|
+                if confirmation_subheader.present?
+                  title.with_subheader_text(confirmation_subheader)
+                end
+              end
+            end
+          )
+
+          content.with_footer do
+            concat(
+              content_tag(:div, class: "w-full inline-flex gap-4") do
+                concat(
+                  button_component(
+                    label: cancel_label,
+                    scheme: :secondary,
+                    **tag_attributes(
+                      {
+                        class: "flex-1",
+                        "data-action": "click->#{Common::ModalComponent.stimulus_identifier}#close"
+                      },
+                      cancel_button_arguments
+                    )
+                  )
+                )
+                concat(
+                  button_component(
+                    label: confirm_label,
+                    scheme: :primary,
+                    **tag_attributes({ class: "flex-1" }, confirm_button_arguments)
+                  )
+                )
+              end
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/common/modal_confirmation_component.rb
+++ b/app/components/common/modal_confirmation_component.rb
@@ -31,7 +31,7 @@ module Common
       @cancel_button_arguments = cancel_button_arguments
     end
 
-    def call
+    def call # rubocop:todo Metrics/AbcSize
       render Common::ModalComponent.new(**content_tag_arguments) do |modal|
         if trigger?
           modal.with_trigger do
@@ -43,9 +43,7 @@ module Common
           concat(
             content_tag(:div, class: "px-8 pt-10 pb-6") do
               title_component(title: confirmation_header, size: :small, class: "text-center") do |title|
-                if confirmation_subheader.present?
-                  title.with_subheader_text(confirmation_subheader)
-                end
+                title.with_subheader_text(confirmation_subheader) if confirmation_subheader.present?
               end
             end
           )

--- a/test/components/previews/common/modal_confirmation_component_preview.rb
+++ b/test/components/previews/common/modal_confirmation_component_preview.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# @label Modal Confirmation Component
+class Common::ModalConfirmationComponentPreview < ViewComponent::Preview
+  include ComponentHelper
+
+  def without_trigger
+    render Common::ModalConfirmationComponent.new(
+      confirm_label: "Delete",
+      cancel_label: "Cancel",
+      confirmation_header: "Delete Event",
+      confirmation_subheader: <<-TEXT
+        Are you sure you want to delete this event?
+        Once deleted data will be lost
+      TEXT
+    )
+  end
+
+  def with_trigger
+    render Common::ModalConfirmationComponent.new(
+      confirm_label: "Delete",
+      cancel_label: "Cancel",
+      confirmation_header: "Delete Event",
+      confirmation_subheader: <<-TEXT
+        Are you sure you want to delete this event?
+        Once deleted data will be lost
+      TEXT
+    ) do |modal|
+      modal.with_trigger do
+        content_tag(:p, "trigger")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Variant of default Modal Component, which displays a title component and two options in the footer, one to perform an operation and the other to cancel it.

https://github.com/AlbertoHdezCerezo/wedding-planner/assets/9349554/86d77e4e-2eb5-421d-b5e7-eef459a4fb5e

