### PR TITLE
feature: invitation page navigation

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -5,6 +5,7 @@ class ApplicationComponent < ViewComponent::Base
   include Turbo::FramesHelper
   include TagAttributeHelper
   include ComponentHelper
+  include StimulusHelper
 
   def self.stimulus_identifier = name.underscore.gsub("/", "--").tr("_", "-")
 

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -7,6 +7,7 @@ class BaseComponent < ApplicationComponent
   def initialize(tag: :div, **content_tag_arguments)
     @tag = tag
     super(**content_tag_arguments)
+    @content_tag_arguments = content_tag_arguments
   end
 
   def call

--- a/app/components/base_component.rb
+++ b/app/components/base_component.rb
@@ -7,7 +7,6 @@ class BaseComponent < ApplicationComponent
   def initialize(tag: :div, **content_tag_arguments)
     @tag = tag
     super(**content_tag_arguments)
-    @content_tag_arguments = content_tag_arguments
   end
 
   def call

--- a/app/components/invitation/layout/application_component.rb
+++ b/app/components/invitation/layout/application_component.rb
@@ -10,9 +10,6 @@ class Invitation::Layout::ApplicationComponent < ApplicationComponent
 
     def default_content_tag_arguments
       {
-        data: {
-          controller: Invitation::Layout::ApplicationComponent.stimulus_identifier
-        },
         class: <<-HTML
           h-screen w-screen flex items-center justify-center
         HTML

--- a/app/components/invitation/layout/application_component_controller.js
+++ b/app/components/invitation/layout/application_component_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from '@hotwired/stimulus'
-
-export default class extends Controller {
-  connect () {
-    console.log('me llama')
-  }
-}

--- a/app/components/invitation/pages/cover.html.haml
+++ b/app/components/invitation/pages/cover.html.haml
@@ -12,4 +12,3 @@
       %span Save the date
       %span •
       %span Alberto & Andrea
-

--- a/app/components/invitation/pages/cover.rb
+++ b/app/components/invitation/pages/cover.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Invitation::Pages::Cover < ApplicationComponent
+class Invitation::Pages::Cover < Invitation::Pages::Page
+  def self.page_name = "cover"
+
   attr_reader :wedding, :guest
 
   def initialize(wedding:, guest:, **system_arguments)

--- a/app/components/invitation/pages/menu.rb
+++ b/app/components/invitation/pages/menu.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Invitation::Pages::Menu < ApplicationComponent
+class Invitation::Pages::Menu < Invitation::Pages::Page
+  def self.page_name = "menu"
+
   attr_reader :wedding, :guest
 
   def initialize(wedding:, guest:, **system_arguments)

--- a/app/components/invitation/pages/page.rb
+++ b/app/components/invitation/pages/page.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::Page < ApplicationComponent
+  def self.page_name = raise "Page Component #{name} does not define page_name method"
+end

--- a/app/components/invitation/pages/schedule.html.haml
+++ b/app/components/invitation/pages/schedule.html.haml
@@ -1,0 +1,9 @@
+= render(Invitation::Layout::PageComponent.new) do
+  .h-full.w-full.overflow-y-scroll.px-4.py-10
+    = title_component(title: 'Schedule')
+
+    -# Events list
+    .mt-10.space-y-4
+      - wedding.events.each do |event|
+        = title_component(size: :small, title: event.name) do |event_title|
+          = event_title.with_subheader_text(event.description)

--- a/app/components/invitation/pages/schedule.rb
+++ b/app/components/invitation/pages/schedule.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::Schedule < Invitation::Pages::Page
+  def self.page_name = "schedule"
+
+  attr_reader :wedding, :guest
+
+  def initialize(wedding:, guest:, **system_arguments)
+    @wedding = wedding
+    @guest = guest
+    super(**system_arguments)
+  end
+end

--- a/app/components/invitation/pages/welcome.html.haml
+++ b/app/components/invitation/pages/welcome.html.haml
@@ -28,8 +28,7 @@
           %span 10600 Plasencia, Cáceres, Spain
           %p.uppercase.leading-4.text-gray-500{ class: "text-[10px] tracking-[.1em]" }
 
-      -# TODO: Fix attribute helper to handle all this in a single line
-      - options = { label: "read schedule", size: :small, scheme: :secondary, class: 'w-full uppercase !text-[10px] tracking-[.05em]' }
-      - options.merge!(stimulus_action_option("click", Invitation::Postcard.stimulus_identifier, "navigateTo"))
-      - options.merge!(stimulus_parameter_option("page_name", Invitation::Postcard.stimulus_identifier, "schedule"))
-      = button_component(**options)
+      - options = ::Html::TagAttributes.build({ label: "read schedule", size: :small, scheme: :secondary, class: 'w-full uppercase !text-[10px] tracking-[.05em]' })
+      - options = options.with_stimulus_action("click", Invitation::Postcard.stimulus_identifier, "navigateTo")
+      - options = options.with_stimulus_parameter("page_name", Invitation::Postcard.stimulus_identifier, "schedule")
+      = button_component(**options.to_h)

--- a/app/components/invitation/pages/welcome.html.haml
+++ b/app/components/invitation/pages/welcome.html.haml
@@ -27,3 +27,9 @@
           %br
           %span 10600 Plasencia, Cáceres, Spain
           %p.uppercase.leading-4.text-gray-500{ class: "text-[10px] tracking-[.1em]" }
+
+      -# TODO: Fix attribute helper to handle all this in a single line
+      - options = { label: "read schedule", size: :small, scheme: :secondary, class: 'w-full uppercase !text-[10px] tracking-[.05em]' }
+      - options.merge!(stimulus_action_option("click", Invitation::Postcard.stimulus_identifier, "navigateTo"))
+      - options.merge!(stimulus_parameter_option("page_name", Invitation::Postcard.stimulus_identifier, "schedule"))
+      = button_component(**options)

--- a/app/components/invitation/pages/welcome.rb
+++ b/app/components/invitation/pages/welcome.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class Invitation::Pages::Welcome < ApplicationComponent
+class Invitation::Pages::Welcome < Invitation::Pages::Page
+  def self.page_name = "welcome"
+
   attr_reader :wedding, :guest
 
   def initialize(wedding:, guest:, **system_arguments)

--- a/app/components/invitation/postcard.html.haml
+++ b/app/components/invitation/postcard.html.haml
@@ -5,6 +5,7 @@
       -# Renders all pages, each one wrapped in a template with the metadata required
       -# by the +javascript+ +Page+ class to navigate between invitation pages.
       - pages.each do |page|
-        %template{ stimulus_target_option("pageTemplate",
-                                          self.stimulus_identifier).merge(data: { page_name: page.page_name }) }
+        - options = stimulus_target_option("pageTemplate", self.stimulus_identifier)
+        - options.merge!(data: { page_name: page.page_name })
+        %template{ options }
           = render page.new(wedding:, guest:)

--- a/app/components/invitation/postcard.html.haml
+++ b/app/components/invitation/postcard.html.haml
@@ -1,4 +1,10 @@
 %div{ content_tag_arguments }
   .flex.flex-row.space-x-16.border-gray-500{ class: "border-[1.5px]" }
     = render Invitation::Pages::Cover.new(wedding:, guest:)
-    = render Invitation::Pages::Welcome.new(wedding:, guest:)
+    .contents{ stimulus_target_option("pageAttachment", self.stimulus_identifier) }
+      -# Renders all pages, each one wrapped in a template with the metadata required
+      -# by the +javascript+ +Page+ class to navigate between invitation pages.
+      - pages.each do |page|
+        %template{ stimulus_target_option("pageTemplate",
+                                          self.stimulus_identifier).merge(data: { page_name: page.page_name }) }
+          = render page.new(wedding:, guest:)

--- a/app/components/invitation/postcard.html.haml
+++ b/app/components/invitation/postcard.html.haml
@@ -1,4 +1,4 @@
-.p-8.shadow-lg{ style: "background-image: url('#{asset_path("postcard-background.svg")}');" }
+%div{ content_tag_arguments }
   .flex.flex-row.space-x-16.border-gray-500{ class: "border-[1.5px]" }
     = render Invitation::Pages::Cover.new(wedding:, guest:)
     = render Invitation::Pages::Welcome.new(wedding:, guest:)

--- a/app/components/invitation/postcard.rb
+++ b/app/components/invitation/postcard.rb
@@ -16,6 +16,7 @@ class Invitation::Postcard < ApplicationComponent
     )
   end
 
+
   private
 
   def default_content_tag_arguments
@@ -23,5 +24,13 @@ class Invitation::Postcard < ApplicationComponent
       class: "p-8 shadow-lg",
       data: { controller: stimulus_identifier },
     }
+  end
+
+  def pages
+    # Ignores component previews, set in the same namespace of the +Page+ components
+    Invitation::Pages.constants
+                     .map(&:to_s)
+                     .grep_v(/(Preview|Page)\z/)
+                     .map { "Invitation::Pages::#{_1}".constantize }
   end
 end

--- a/app/components/invitation/postcard.rb
+++ b/app/components/invitation/postcard.rb
@@ -16,13 +16,12 @@ class Invitation::Postcard < ApplicationComponent
     )
   end
 
-
   private
 
   def default_content_tag_arguments
     {
       class: "p-8 shadow-lg",
-      data: { controller: stimulus_identifier },
+      data: { controller: stimulus_identifier }
     }
   end
 

--- a/app/components/invitation/postcard.rb
+++ b/app/components/invitation/postcard.rb
@@ -8,4 +8,20 @@ class Invitation::Postcard < ApplicationComponent
     @guest = guest
     super(**system_arguments)
   end
+
+  # Required to use +asset_path+ during component rendering
+  def before_render
+    @content_tag_arguments.merge!(
+      style: "background-image: url('#{asset_path("postcard-background.svg")}')"
+    )
+  end
+
+  private
+
+  def default_content_tag_arguments
+    {
+      class: "p-8 shadow-lg",
+      data: { controller: stimulus_identifier },
+    }
+  end
 end

--- a/app/components/invitation/postcard_controller.js
+++ b/app/components/invitation/postcard_controller.js
@@ -24,10 +24,10 @@ export default class extends Controller {
 
   connect () {
     this.pageNavigator = new Navigator(this.pageTemplateTargets, this.pageAttachmentTarget)
-    this.navigateTo('welcome')
+    this.navigateTo({ params: { pageName: 'welcome' } })
   }
 
-  navigateTo (pageName) {
+  navigateTo ({ params: { pageName } }) {
     this.pageNavigator.navigateTo(pageName)
   }
 }

--- a/app/components/invitation/postcard_controller.js
+++ b/app/components/invitation/postcard_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { Navigator } from '../../javascript/src/invitation/navigator'
 
 /**
  * Implement the invitation logic to navigate between the different
@@ -23,6 +24,7 @@ export default class extends Controller {
 
   connect () {
     this.pageNavigator = new Navigator(this.pageTemplateTargets, this.pageAttachmentTarget)
+    this.navigateTo('welcome')
   }
 
   navigateTo (pageName) {

--- a/app/components/invitation/postcard_controller.js
+++ b/app/components/invitation/postcard_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus'
+
+/**
+ * Implement the invitation logic to navigate between the different
+ * its different pages (welcome, schedule, etc.).
+ *
+ * The postcard is composed by multiple pages, each one encapsulated
+ * within a `template` element with some basic metadata information.
+ * The controller counts with different actions for page navigation.
+ * To navigate between pages, the controller uses the page metadata
+ * information and the `template` content to render each page in a
+ * programmatic way, giving the impression of a SPA.
+ */
+export default class extends Controller {
+  static targets = [
+    // Each one of the `template` elements containing invitation pages
+    'pageTemplate',
+    // Attachment point for pages
+    'pageAttachment'
+  ]
+
+  pageNavigator = null
+
+  connect () {
+    this.pageNavigator = new Navigator(this.pageTemplateTargets, this.pageAttachmentTarget)
+  }
+
+  navigateTo (pageName) {
+    this.pageNavigator.navigateTo(pageName)
+  }
+}

--- a/app/helpers/stimulus_helper.rb
+++ b/app/helpers/stimulus_helper.rb
@@ -9,12 +9,16 @@ module StimulusHelper
     "#{event}->#{controller_identifier}##{action}"
   end
 
-  def stimulus_css_class_key(controller_identifier, class_name)
-    "data-#{controller_identifier}-#{class_name}-class"
+  def stimulus_controller_option(controller_identifier)
+    { "data-controller" => controller_identifier }
   end
 
-  def stimulus_css_class_option(controller_identifier, class_name, css_class)
+  def stimulus_css_class_option(class_name, controller_identifier, css_class)
     { stimulus_css_class_key(controller_identifier, class_name) => css_class }
+  end
+
+  def stimulus_css_class_key(controller_identifier, class_name)
+    "data-#{controller_identifier}-#{class_name}-class"
   end
 
   def stimulus_parameter_option(name, controller_identifier, value)
@@ -31,7 +35,7 @@ module StimulusHelper
 
   def stimulus_target_key(controller_identifier) = "data-#{controller_identifier}-target"
 
-  def stimulus_value_option(controller_identifier, value_name, value)
+  def stimulus_value_option(value_name, controller_identifier, value)
     { stimulus_value_key(controller_identifier, value_name) => value }
   end
 

--- a/app/helpers/stimulus_helper.rb
+++ b/app/helpers/stimulus_helper.rb
@@ -5,30 +5,38 @@ module StimulusHelper
     { "data-action" => stimulus_action_value(event, controller_identifier, action) }
   end
 
-  def stimulus_css_class_option(controller_identifier, class_name, css_class)
-    { stimulus_css_class_key(controller_identifier, class_name) => css_class }
-  end
-
-  def stimulus_target_option(name, controller_identifier)
-    { stimulus_target_key(controller_identifier) => name }
-  end
-
-  def stimulus_value_option(controller_identifier, value_name, value)
-    { stimulus_value_key(controller_identifier, value_name) => value }
+  def stimulus_action_value(event, controller_identifier, action)
+    "#{event}->#{controller_identifier}##{action}"
   end
 
   def stimulus_css_class_key(controller_identifier, class_name)
     "data-#{controller_identifier}-#{class_name}-class"
   end
 
+  def stimulus_css_class_option(controller_identifier, class_name, css_class)
+    { stimulus_css_class_key(controller_identifier, class_name) => css_class }
+  end
+
+  def stimulus_parameter_option(name, controller_identifier, value)
+    { stimulus_parameter_key(name, controller_identifier) => value }
+  end
+
+  def stimulus_parameter_key(name, controller_identifier)
+    "data-#{controller_identifier}-#{dasherize(name)}-param"
+  end
+
+  def stimulus_target_option(name, controller_identifier)
+    { stimulus_target_key(controller_identifier) => name }
+  end
+
   def stimulus_target_key(controller_identifier) = "data-#{controller_identifier}-target"
+
+  def stimulus_value_option(controller_identifier, value_name, value)
+    { stimulus_value_key(controller_identifier, value_name) => value }
+  end
 
   def stimulus_value_key(controller_identifier, value_name)
     "data-#{controller_identifier}-#{dasherize(value_name)}-value"
-  end
-
-  def stimulus_action_value(event, controller_identifier, action)
-    "#{event}->#{controller_identifier}##{action}"
   end
 
   private

--- a/app/helpers/stimulus_helper.rb
+++ b/app/helpers/stimulus_helper.rb
@@ -17,11 +17,6 @@ module StimulusHelper
     { stimulus_value_key(controller_identifier, value_name) => value }
   end
 
-  private
-
-  # Special dasherize logic for Stimulus related keys (like value names)
-  def dasherize(string) = string.to_s.underscore.dasherize.gsub("/", "--")
-
   def stimulus_css_class_key(controller_identifier, class_name)
     "data-#{controller_identifier}-#{class_name}-class"
   end
@@ -35,4 +30,9 @@ module StimulusHelper
   def stimulus_action_value(event, controller_identifier, action)
     "#{event}->#{controller_identifier}##{action}"
   end
+
+  private
+
+  # Special dasherize logic for Stimulus related keys (like value names)
+  def dasherize(string) = string.to_s.underscore.dasherize.gsub("/", "--")
 end

--- a/app/helpers/stimulus_helper.rb
+++ b/app/helpers/stimulus_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module StimulusHelper
+  def stimulus_action_option(event, controller_identifier, action)
+    { "data-action" => stimulus_action_value(event, controller_identifier, action) }
+  end
+
+  def stimulus_css_class_option(controller_identifier, class_name, css_class)
+    { stimulus_css_class_key(controller_identifier, class_name) => css_class }
+  end
+
+  def stimulus_target_option(name, controller_identifier)
+    { stimulus_target_key(controller_identifier) => name }
+  end
+
+  def stimulus_value_option(controller_identifier, value_name, value)
+    { stimulus_value_key(controller_identifier, value_name) => value }
+  end
+
+  private
+
+  # Special dasherize logic for Stimulus related keys (like value names)
+  def dasherize(string) = string.to_s.underscore.dasherize.gsub("/", "--")
+
+  def stimulus_css_class_key(controller_identifier, class_name)
+    "data-#{controller_identifier}-#{class_name}-class"
+  end
+
+  def stimulus_target_key(controller_identifier) = "data-#{controller_identifier}-target"
+
+  def stimulus_value_key(controller_identifier, value_name)
+    "data-#{controller_identifier}-#{dasherize(value_name)}-value"
+  end
+
+  def stimulus_action_value(event, controller_identifier, action)
+    "#{event}->#{controller_identifier}##{action}"
+  end
+end

--- a/app/javascript/src/invitation/navigator.js
+++ b/app/javascript/src/invitation/navigator.js
@@ -37,7 +37,9 @@ export class Page {
   }
 
   attach (attachmentTarget) {
-    return attachmentTarget.appendChild(this.layout)
+    attachmentTarget.appendChild(this.layout)
+    this.instance = attachmentTarget.lastElementChild
+    return this.instance
   }
 
   detach () {

--- a/app/javascript/src/invitation/navigator.js
+++ b/app/javascript/src/invitation/navigator.js
@@ -2,8 +2,7 @@
 export class Page {
   // Verifies template complies with format constraints to be treated as page
   static valid (template) {
-    return template.tagName.toLowerCase() === 'template' &&
-      template.dataset.name !== undefined
+    return template.tagName.toLowerCase() === 'template' && !!template.dataset.pageName
   }
 
   // element template representing an invitation page
@@ -26,7 +25,7 @@ export class Page {
   }
 
   get name () {
-    return this.template.dataset.name
+    return this.template.dataset.pageName
   }
 
   get layout () {

--- a/app/javascript/src/invitation/navigator.js
+++ b/app/javascript/src/invitation/navigator.js
@@ -1,0 +1,82 @@
+// Represents an invitation page (welcome, schedule, etc).
+export class Page {
+  // Verifies template complies with format constraints to be treated as page
+  static valid (template) {
+    return template.tagName.toLowerCase() === 'template' &&
+      template.dataset.name !== undefined
+  }
+
+  // element template representing an invitation page
+  template = null
+  // element representing page, when this is rendered out of template
+  instance = null
+
+  constructor (template) {
+    if (!Page.valid(template)) {
+      throw new Error(
+      `
+        Attemp to instantiate InvitationPage with invalid template.
+        Make sure all your Page-base components present a layout
+        with a root template element and a dataset with the name property.
+      `
+      )
+    }
+
+    this.template = template
+  }
+
+  get name () {
+    return this.template.dataset.name
+  }
+
+  get layout () {
+    return this.template.content.cloneNode(true)
+  }
+
+  attached () {
+    return this.instance !== null
+  }
+
+  attach (attachmentTarget) {
+    return attachmentTarget.appendChild(this.layout)
+  }
+
+  detach () {
+    if (this.attached()) {
+      this.instance.remove()
+      this.instance = null
+    }
+  }
+}
+
+export class Navigator {
+  // element to which pages are attached
+  attachmentTarget = null
+  // list of available pages
+  pages = []
+  // current attached page
+  currentPage = null
+
+  constructor (pageTemplates, attachmentTarget) {
+    this.pages = pageTemplates.map((template) => new Page(template))
+    this.attachmentTarget = attachmentTarget
+  }
+
+  page (name) {
+    return this.pages.find((page) => page.name === name)
+  }
+
+  /**
+   * Switch between pages. Replaces current page (if there is one attached)
+   * by the given one. If no page is attached, the given page is attached.
+   * @param {String} name
+   */
+  navigateTo (name) {
+    const page = this.page(name)
+
+    if (this.currentPage && this.currentPage.attached()) { this.currentPage.detach() }
+
+    page.attach(this.attachmentTarget)
+    this.currentPage = page
+  }
+}

--- a/app/lib/html/tag_attributes.rb
+++ b/app/lib/html/tag_attributes.rb
@@ -2,6 +2,8 @@
 
 module Html
   TagAttributes = Data.define(:attributes) do
+    include StimulusHelper
+
     def self.build(*hashes)
       flattened_hashes = hashes.map { flattened_hash(_1) }
       attribute_names = flattened_hashes.flat_map(&:keys).uniq
@@ -33,5 +35,39 @@ module Html
     end
 
     def to_h = attributes.flat_map { _1.to_h.to_a }.to_h
+
+    # Returns new +TagAttributes+ resulting from adding a +Stimulus+
+    # +data-action+ attribute to the attributes payload
+    def with_stimulus_action(event, controller_identifier, action)
+      self.class.build(to_h, stimulus_action_option(event, controller_identifier, action))
+    end
+
+    def with_stimulus_controller(controller_identifier)
+      self.class.build(to_h, stimulus_controller_option(controller_identifier))
+    end
+
+    # Returns new +TagAttributes+ resulting from adding a +Stimulus+
+    # +data-*-class+ attribute to the attributes payload
+    def with_stimulus_css_class(class_name, controller_identifier, css_class)
+      self.class.build(to_h, stimulus_css_class_option(class_name, controller_identifier, css_class))
+    end
+
+    # Returns new +TagAttributes+ resulting from adding a +Stimulus+
+    # +data-*-param+ attribute to the attributes payload
+    def with_stimulus_parameter(name, controller_identifier, value)
+      self.class.build(to_h, stimulus_parameter_option(name, controller_identifier, value))
+    end
+
+    # Returns new +TagAttributes+ resulting from adding a +Stimulus+
+    # +data-*-target+ attribute to the attributes payload
+    def with_stimulus_target(name, controller_identifier)
+      self.class.build(to_h, stimulus_target_option(name, controller_identifier))
+    end
+
+    # Returns new +TagAttributes+ resulting from adding a +Stimulus+
+    # +data-*-target+ attribute to the attributes payload
+    def with_stimulus_value(value_name, controller_identifier, value)
+      self.class.build(to_h, stimulus_value_option(value_name, controller_identifier, value))
+    end
   end
 end

--- a/app/lib/html/tag_attributes.rb
+++ b/app/lib/html/tag_attributes.rb
@@ -3,9 +3,33 @@
 module Html
   TagAttributes = Data.define(:attributes) do
     def self.build(*hashes)
-      attribute_names = hashes.flat_map(&:keys).uniq
+      flattened_hashes = hashes.map { flattened_hash(_1) }
+      attribute_names = flattened_hashes.flat_map(&:keys).uniq
 
-      new(attributes: attribute_names.map { |name| Attribute.build(*hashes, name:) })
+      new(attributes: attribute_names.map { |name| Attribute.build(*flattened_hashes, name:) })
+    end
+
+    # When we work with HTML attributes, the DOM does not handle nested
+    # attributes (for example, { data: { foo: true, bar: false } } would
+    # be represented as HTML attributes data-foo="true" & data-bar="false").
+    #
+    # This method flattens Hashes with nested Hashes so keys are
+    # presented in an HTML attribute equivalent format (in the
+    # example case,{ "data-foo": true, "data-bar": false })
+    def self.flattened_hash(hash, parent_key = nil)
+      result = {}
+
+      hash.each do |key, value|
+        current_key = (parent_key ? "#{parent_key}-#{key}" : key).to_sym
+
+        if value.is_a?(Hash)
+          result.merge!(flattened_hash(value, current_key))
+        else
+          result[current_key] = value
+        end
+      end
+
+      result
     end
 
     def to_h = attributes.flat_map { _1.to_h.to_a }.to_h

--- a/test/components/previews/invitation/pages/schedule_preview.rb
+++ b/test/components/previews/invitation/pages/schedule_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::SchedulePreview < ViewComponent::Preview
+  def default
+    wedding = FactoryBot.build(:wedding)
+    wedding.events = FactoryBot.build_list(:event, 3, wedding:)
+    guest = FactoryBot.build(:guest)
+    render(Invitation::Pages::Schedule.new(wedding:, guest:))
+  end
+end

--- a/test/helpers/stimulus_helper_test.rb
+++ b/test/helpers/stimulus_helper_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StimulusHelperTest < ActiveSupport::TestCase
+  include StimulusHelper
+
+  test "#stimulus_action_option returns hash with right Stimulus action value" do
+    assert_equal(
+      { "data-action" => "click->myController#myAction" },
+      stimulus_action_option("click", "myController", "myAction")
+    )
+  end
+
+  test "#stimulus_css_class_option returns hash with right Stimulus css class key" do
+    assert_equal(
+      { "data-my-controller-sample-class" => "css-class" },
+      stimulus_css_class_option("my-controller", "sample", "css-class")
+    )
+  end
+
+  test "#stimulus_target_option returns hash with right Stimulus target key and value" do
+    assert_equal(
+      { "data-my-controller-target" => "myTarget" },
+      stimulus_target_option("myTarget", "my-controller")
+    )
+  end
+
+  test "#stimulus_value_option returns hash with right Stimulus value key and value" do
+    assert_equal(
+      { "data-my-controller-sample-value" => "myValue" },
+      stimulus_value_option("my-controller", "sample", "myValue")
+    )
+  end
+end

--- a/test/helpers/stimulus_helper_test.rb
+++ b/test/helpers/stimulus_helper_test.rb
@@ -15,7 +15,7 @@ class StimulusHelperTest < ActiveSupport::TestCase
   test "#stimulus_css_class_option returns hash with right Stimulus css class key" do
     assert_equal(
       { "data-my-controller-sample-class" => "css-class" },
-      stimulus_css_class_option("my-controller", "sample", "css-class")
+      stimulus_css_class_option("sample", "my-controller", "css-class")
     )
   end
 
@@ -29,7 +29,7 @@ class StimulusHelperTest < ActiveSupport::TestCase
   test "#stimulus_value_option returns hash with right Stimulus value key and value" do
     assert_equal(
       { "data-my-controller-sample-value" => "myValue" },
-      stimulus_value_option("my-controller", "sample", "myValue")
+      stimulus_value_option("sample", "my-controller", "myValue")
     )
   end
 end

--- a/test/lib/html/tag_attributes_test.rb
+++ b/test/lib/html/tag_attributes_test.rb
@@ -11,6 +11,6 @@ class Html::AttributeTest < ActiveSupport::TestCase
 
     attributes = Html::TagAttributes.build(*hashes).to_h
 
-    assert_equal({ class: "px-1 py-2", data: { foo: true, bar: true }, id: "test2", disabled: true }, attributes)
+    assert_equal({ class: "px-1 py-2", "data-foo": true, id: "test2", "data-bar": true, disabled: true }, attributes)
   end
 end


### PR DESCRIPTION
Implements new logic to navigate between different pages within the Postcard Invitation.

I noticed some issues with the `TagAttributes` class during the development. These problems have been fixed in the current PR, and additional enhancements have been made to the logic to have a simpler `Stimulus` `data` attribute handling.

https://github.com/AlbertoHdezCerezo/wedding-planner/assets/9349554/b3d7c85b-cf4d-4905-8e95-c69d406cde90