### PR TITLE
chore: Adjusts `Attribute` logic to handle multi-value HTML attributes.

### DIFF
--- a/app/lib/html/attribute.rb
+++ b/app/lib/html/attribute.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 module Html
-  CLASS_ATTRIBUTE = "class"
+  # List of attributes which admit multiple values.
+  ATTRIBUTES_WITH_MULTIPLE_VALUES = %w[class data-action].freeze
   PREFIXED_ATTRIBUTES = %w[data aria].freeze
 
   Attribute = Data.define(:name, :value) do
     extend Helpers::ClassNameHelper, Helpers::AttributesHelper
 
     class << self
+      # Given an attribute +name+, seeks in the array of +hashes+ the last
+      # hash which contaions a key with the same +name+ and assigns its
+      # value to the returned +Attribute+.
+      #
+      # For special HTML attributes such as +class+ or +data-action+, the
+      # method finds all +name+ keys in +hashes+ and concatenates them into
+      # a single +String+ as value for the returned +Attribute+
       def build(*hashes, name:)
-        value = if class_attribute?(name.to_s)
-                  class_names(*hashes.pluck(:class).compact)
+        value = if attribute_with_multiple_values?(name.to_s)
+                  class_names(*hashes.pluck(name.to_sym).compact)
                 elsif prefixed_attribute?(name.to_s)
                   prefixed_attribute_value(*hashes, prefix: name)
                 else
@@ -22,7 +30,7 @@ module Html
 
       private
 
-      def class_attribute?(name) = name == CLASS_ATTRIBUTE
+      def attribute_with_multiple_values?(name) = ATTRIBUTES_WITH_MULTIPLE_VALUES.include?(name)
 
       def prefixed_attribute?(name) = PREFIXED_ATTRIBUTES.include?(name)
     end

--- a/test/lib/html/attribute_test.rb
+++ b/test/lib/html/attribute_test.rb
@@ -36,6 +36,16 @@ class Html::AttributeTest < ActiveSupport::TestCase
     assert_equal({ foo: true, bar: true }, attribute.value)
   end
 
+  test ".build if attribute name is data-action, return 'data-action' values from each hash joint" do
+    attribute = Html::Attribute.build(
+      { "data-action": "click->clipboard#copy" },
+      { "data-action": "click->navigator#openPage" },
+      name: "data-action"
+    )
+
+    assert_equal "click->clipboard#copy click->navigator#openPage", attribute.value
+  end
+
   test ".build if attribute name is aria, return data prefixed attribute" do
     attribute = Html::Attribute.build({ aria: { foo: true } }, { "aria-bar": true }, {}, name: :aria)
 

--- a/test/lib/html/tag_attributes_test.rb
+++ b/test/lib/html/tag_attributes_test.rb
@@ -5,12 +5,15 @@ require "test_helper"
 class Html::AttributeTest < ActiveSupport::TestCase
   test ".build returns hashes attributes" do
     hashes = [
-      { class: "px-1", data: { foo: true }, id: "test1" },
-      { class: "py-2", data: { bar: true }, id: "test2", disabled: true }
+      { class: "px-1", data: { foo: true, action: "foo" }, id: "test1" },
+      { class: "py-2", data: { bar: true }, "data-action": "bar", id: "test2", disabled: true }
     ]
 
     attributes = Html::TagAttributes.build(*hashes).to_h
 
-    assert_equal({ class: "px-1 py-2", "data-foo": true, id: "test2", "data-bar": true, disabled: true }, attributes)
+    assert_equal(
+      { class: "px-1 py-2", "data-foo": true, "data-action": "foo bar", id: "test2", "data-bar": true, disabled: true },
+      attributes
+    )
   end
 end


### PR DESCRIPTION
In a previous PR I defined the ClassNameHelper. This helper concatenates multiple values representing CSS classes into a single string with all class names which can be passed to an HTML element data attribute.

Now I am using the same helper in the `Attribute` class to handle other HTML attributes which, similar to the `class` attribute, can accept multiple values.

For example, a `Stimulus` `data-action` attribute can define multiple actions, each one concatenated in a single string and separated by spaces. For attributes like this, the new +Attribute+ class can be extended in order to extract the value in the same way we did with the `class` attribute.