### PR TITLE
feature: invitation schedule page

### DIFF
--- a/app/components/invitation/pages/schedule.html.haml
+++ b/app/components/invitation/pages/schedule.html.haml
@@ -4,25 +4,26 @@
 
     -# Events list
     .mt-12
-      - place = wedding.events.first.place
-      - first_event = wedding.events.first
-      %div{ class: "flex flex-row justify-between items-center pb-8 border-b-[1px] border-gray-200" }
-        %p{ class: "w-[50px] font-newsreader uppercase text-center text-gray-700" }
-          %span.text-xs= l(first_event.schedule.begin.to_date, format: :abbreviated_month)
-          %br
-          %span.font-newsreader.text-2xl{ class: "tracking-[.05em]" }= first_event.schedule.begin.day
+      - schedule_decorator.event_group_decorators.each do |event_group_decorator|
+        - address_decorator = event_group_decorator.place_decorator.address_decorator
 
-        %div{ class: "max-w-[65%] space-y-1" }
-          %p{ class: "text-gray-700 text-xs uppercase tracking-[.15em]" } Parador de Plasencia
-          %p{ class: "text-gray-400 text-xs" } Pl. de San Vicente Ferrer, Plasencia, Spain
+        %div{ class: "flex flex-row justify-between items-center pb-6 border-b-[1px] border-gray-200" }
+          %p{ class: "w-[50px] font-newsreader uppercase text-center text-gray-700" }
+            %span.text-xs= l(event_group_decorator.time_range.begin.to_date, format: :abbreviated_month)
+            %br
+            %span.font-newsreader.text-2xl{ class: "tracking-[.05em]" }= event_group_decorator.time_range.begin.day
 
-        = icon_component(icon: "map-pin", size: :small, scheme: :invisible, class: "text-gray-400")
+          %div{ class: "max-w-[65%] space-y-1" }
+            %p{ class: "text-gray-700 text-xs uppercase tracking-[.15em]" }= event_group_decorator.place_decorator.name
+            %p{ class: "text-gray-400 text-xs" }= address_decorator.full_address
 
-      - wedding.events.each do |event|
-        .flex.flex-row.space-x-6.items-center.divide-x.divide-gray-200
-          %div{ class: "min-w-[50px]" }
-            = icon_component(icon: "calendar", size: :small, class: "m-auto text-gray-500")
-          .relative.space-y-1.pl-8.py-6
-            .absolute.h-2.w-2.rounded-full.bg-gray-500{ class: "left-[-4.5px] top-[48%]" }
-            %p.text-gray-500.text-xs{ class: "uppercase tracking-[.10em]" }= l(event.schedule.begin, format: :short_time)
-            %p.text-gray-700.text-xs{ class: "uppercase tracking-[.2em]" }= event.name
+          = icon_component(icon: "map-pin", size: :small, scheme: :invisible, class: "text-gray-400")
+
+        - event_group_decorator.event_decorators.each do |event_decorator|
+          .flex.flex-row.space-x-6.items-center.divide-x.divide-gray-200
+            %div{ class: "min-w-[50px]" }
+              = icon_component(icon: "calendar", size: :small, class: "m-auto text-gray-500")
+            .relative.space-y-1.pl-8.py-6
+              .absolute.h-2.w-2.rounded-full.bg-gray-500{ class: "left-[-4.5px] top-[48%]" }
+              %p.text-gray-500.text-xs{ class: "uppercase tracking-[.10em]" }= l(event_decorator.schedule.begin, format: :short_time)
+              %p.text-gray-700.text-xs{ class: "uppercase tracking-[.2em]" }= event_decorator.name

--- a/app/components/invitation/pages/schedule.html.haml
+++ b/app/components/invitation/pages/schedule.html.haml
@@ -5,17 +5,15 @@
     -# Events list
     .mt-12
       - schedule_decorator.event_group_decorators.each do |event_group_decorator|
-        - address_decorator = event_group_decorator.place_decorator.address_decorator
-
         %div{ class: "flex flex-row justify-between items-center pb-6 border-b-[1px] border-gray-200" }
           %p{ class: "w-[50px] font-newsreader uppercase text-center text-gray-700" }
-            %span.text-xs= l(event_group_decorator.time_range.begin.to_date, format: :abbreviated_month)
+            %span.text-xs= event_group_decorator.abbreviated_start_month
             %br
-            %span.font-newsreader.text-2xl{ class: "tracking-[.05em]" }= event_group_decorator.time_range.begin.day
+            %span.font-newsreader.text-2xl{ class: "tracking-[.05em]" }= event_group_decorator.start_day
 
           %div{ class: "max-w-[65%] space-y-1" }
-            %p{ class: "text-gray-700 text-xs uppercase tracking-[.15em]" }= event_group_decorator.place_decorator.name
-            %p{ class: "text-gray-400 text-xs" }= address_decorator.full_address
+            %p{ class: "text-gray-700 text-xs uppercase tracking-[.15em]" }= event_group_decorator.place_name
+            %p{ class: "text-gray-400 text-xs" }= event_group_decorator.full_address
 
           = icon_component(icon: "map-pin", size: :small, scheme: :invisible, class: "text-gray-400")
 
@@ -25,5 +23,5 @@
               = icon_component(icon: "calendar", size: :small, class: "m-auto text-gray-500")
             .relative.space-y-1.pl-8.py-6
               .absolute.h-2.w-2.rounded-full.bg-gray-500{ class: "left-[-4.5px] top-[48%]" }
-              %p.text-gray-500.text-xs{ class: "uppercase tracking-[.10em]" }= l(event_decorator.schedule.begin, format: :short_time)
+              %p.text-gray-500.text-xs{ class: "uppercase tracking-[.10em]" }= event_decorator.start_time
               %p.text-gray-700.text-xs{ class: "uppercase tracking-[.2em]" }= event_decorator.name

--- a/app/components/invitation/pages/schedule.html.haml
+++ b/app/components/invitation/pages/schedule.html.haml
@@ -1,9 +1,28 @@
 = render(Invitation::Layout::PageComponent.new) do
-  .h-full.w-full.overflow-y-scroll.px-4.py-10
-    = title_component(title: 'Schedule')
+  .h-full.w-full.overflow-y-scroll.px-10.py-16
+    = title_component(title: "Order of Events", size: :small, class: "text-center uppercase tracking-[.15em]")
 
     -# Events list
-    .mt-10.space-y-4
+    .mt-12
+      - place = wedding.events.first.place
+      - first_event = wedding.events.first
+      %div{ class: "flex flex-row justify-between items-center pb-8 border-b-[1px] border-gray-200" }
+        %p{ class: "w-[50px] font-newsreader uppercase text-center text-gray-700" }
+          %span.text-xs= l(first_event.schedule.begin.to_date, format: :abbreviated_month)
+          %br
+          %span.font-newsreader.text-2xl{ class: "tracking-[.05em]" }= first_event.schedule.begin.day
+
+        %div{ class: "max-w-[65%] space-y-1" }
+          %p{ class: "text-gray-700 text-xs uppercase tracking-[.15em]" } Parador de Plasencia
+          %p{ class: "text-gray-400 text-xs" } Pl. de San Vicente Ferrer, Plasencia, Spain
+
+        = icon_component(icon: "map-pin", size: :small, scheme: :invisible, class: "text-gray-400")
+
       - wedding.events.each do |event|
-        = title_component(size: :small, title: event.name) do |event_title|
-          = event_title.with_subheader_text(event.description)
+        .flex.flex-row.space-x-6.items-center.divide-x.divide-gray-200
+          %div{ class: "min-w-[50px]" }
+            = icon_component(icon: "calendar", size: :small, class: "m-auto text-gray-500")
+          .relative.space-y-1.pl-8.py-6
+            .absolute.h-2.w-2.rounded-full.bg-gray-500{ class: "left-[-4.5px] top-[48%]" }
+            %p.text-gray-500.text-xs{ class: "uppercase tracking-[.10em]" }= l(event.schedule.begin, format: :short_time)
+            %p.text-gray-700.text-xs{ class: "uppercase tracking-[.2em]" }= event.name

--- a/app/components/invitation/pages/schedule.rb
+++ b/app/components/invitation/pages/schedule.rb
@@ -3,11 +3,11 @@
 class Invitation::Pages::Schedule < Invitation::Pages::Page
   def self.page_name = "schedule"
 
-  attr_reader :wedding, :guest
+  attr_reader :schedule, :schedule_decorator
 
   def initialize(wedding:, guest:, **system_arguments)
-    @wedding = wedding
-    @guest = guest
+    @schedule = Schedule.new(wedding:, guest:)
+    @schedule_decorator = ScheduleDecorator.new(@schedule)
     super(**system_arguments)
   end
 end

--- a/app/decorators/address_decorator.rb
+++ b/app/decorators/address_decorator.rb
@@ -2,4 +2,6 @@
 
 class AddressDecorator < ApplicationDecorator
   def town_address = "#{town}, #{zip_code}, #{country}"
+
+  def full_address = "#{street}, #{town}, #{zip_code}, #{country}"
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -7,4 +7,7 @@ class EventDecorator < ApplicationDecorator
     @place_decorator = PlaceDecorator.new(event.place) if event.place.present?
     super(event)
   end
+
+  # Event start time in hh:mm format
+  def start_time = I18n.l(schedule.begin, format: :short_time)
 end

--- a/app/decorators/events_group_decorator.rb
+++ b/app/decorators/events_group_decorator.rb
@@ -8,4 +8,18 @@ class EventsGroupDecorator < ApplicationDecorator
     @event_decorators = event_group.events.map { EventDecorator.new(_1) }
     super(event_group)
   end
+
+  # Event group starting event starting month in abbreviated format
+  # e.g. "Jan" for January
+  def abbreviated_start_month
+    I18n.l(time_range.begin.to_date, format: :abbreviated_month)
+  end
+
+  def full_address = place_decorator&.address_decorator&.full_address
+
+  def place_name = place_decorator&.name
+
+  # Event group starting event starting day
+  # e.g. "1" for 1st of January
+  def start_day = time_range.begin.day
 end

--- a/app/decorators/events_group_decorator.rb
+++ b/app/decorators/events_group_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EventsGroupDecorator < ApplicationDecorator
+  attr_reader :event_decorators, :place_decorator
+
+  def initialize(event_group)
+    @place_decorator = PlaceDecorator.new(event_group.place) if event_group.place.present?
+    @event_decorators = event_group.events.map { EventDecorator.new(_1) }
+    super(event_group)
+  end
+end

--- a/app/decorators/schedule_decorator.rb
+++ b/app/decorators/schedule_decorator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ScheduleDecorator < ApplicationDecorator
+  attr_reader :event_group_decorators
+
+  def initialize(event)
+    @event_group_decorators = event.event_groups.map { EventsGroupDecorator.new(_1) }
+    super(event)
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -13,7 +13,7 @@ class Schedule
                        .sort { |event1, event2| event1.schedule.begin <=> event2.schedule.begin }
     end
 
-    def schedule = events.first.schedule.begin..events.last.schedule.end
+    def time_range = events.first.schedule.begin..events.last.schedule.end
   end
 
   attr_reader :wedding, :guest
@@ -30,7 +30,7 @@ class Schedule
   def event_groups
     @event_groups ||= wedding_places
                       .map { |place| EventsGroup.new(wedding:, place:) }
-                      .sort { |group1, group2| group1.schedule.begin <=> group2.schedule.begin }
+                      .sort { |group1, group2| group1.time_range.begin <=> group2.time_range.begin }
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
       short_time: "%H:%M"
       short_month_day: "%b %d"
       short_date_time: "%H:%M, %d/%m"
+      abbreviated_month: "%b"
   time:
     formats:
       short_time: "%H:%M"

--- a/lib/factories/schedules.rb
+++ b/lib/factories/schedules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :schedule do
+    wedding
+  end
+end

--- a/lib/factories/schedules.rb
+++ b/lib/factories/schedules.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :schedule do
-    wedding
-  end
-end

--- a/test/components/previews/invitation/pages/schedule_preview.rb
+++ b/test/components/previews/invitation/pages/schedule_preview.rb
@@ -3,7 +3,7 @@
 class Invitation::Pages::SchedulePreview < ViewComponent::Preview
   def default
     wedding = Invitation::ShowComponentPreview.wedding
-    guest = FactoryBot.build(:guest)
+    guest = wedding.guests.first
     render(Invitation::Pages::Schedule.new(wedding:, guest:))
   end
 end

--- a/test/components/previews/invitation/pages/schedule_preview.rb
+++ b/test/components/previews/invitation/pages/schedule_preview.rb
@@ -2,8 +2,7 @@
 
 class Invitation::Pages::SchedulePreview < ViewComponent::Preview
   def default
-    wedding = FactoryBot.build(:wedding)
-    wedding.events = FactoryBot.build_list(:event, 3, wedding:)
+    wedding = Invitation::ShowComponentPreview.wedding
     guest = FactoryBot.build(:guest)
     render(Invitation::Pages::Schedule.new(wedding:, guest:))
   end

--- a/test/components/previews/invitation/show_component_preview.rb
+++ b/test/components/previews/invitation/show_component_preview.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
 class Invitation::ShowComponentPreview < ViewComponent::Preview
-  def self.wedding
+  def self.wedding # rubocop:todo Metrics/AbcSize
     date = Date.new(2024, 9, 14)
 
     wedding = FactoryBot.build(:wedding, date:, guests: FactoryBot.build_list(:guest, 1))
     place = FactoryBot.build(:place, name: "Parador de Plasencia")
 
-    wedding.events << FactoryBot.build(:event, name: "Welcome Cocktail", schedule: (date + 15.hours)..(date + 17.hours), place:)
-    wedding.events << FactoryBot.build(:event, name: "Engagement Ceremony", schedule: (date + 17.hours)..(date + 18.hours), place:)
-    wedding.events << FactoryBot.build(:event, name: "Wedding Dinner", schedule: (date + 18.hours)..(date + 20.hours), place:)
-    wedding.events << FactoryBot.build(:event, name: "Dance Party", schedule: (date + 20.hours)..(date + 24.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Welcome Cocktail",
+                                               schedule: (date + 15.hours)..(date + 17.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Engagement Ceremony",
+                                               schedule: (date + 17.hours)..(date + 18.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Wedding Dinner", schedule: (date + 18.hours)..(date + 20.hours),
+                                               place:)
+    wedding.events << FactoryBot.build(:event, name: "Dance Party", schedule: (date + 20.hours)..(date + 24.hours),
+                                               place:)
 
     wedding
   end

--- a/test/components/previews/invitation/show_component_preview.rb
+++ b/test/components/previews/invitation/show_component_preview.rb
@@ -1,10 +1,37 @@
 # frozen_string_literal: true
 
 class Invitation::ShowComponentPreview < ViewComponent::Preview
+  def self.wedding
+    date = Date.new(2024, 9, 14)
+
+    wedding = FactoryBot.build(:wedding, date:)
+
+    wedding.events << FactoryBot.build(:event, name: "Welcome Cocktail", schedule: (date + 15.hours)..(date + 17.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Engagement Ceremony", schedule: (date + 17.hours)..(date + 18.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Wedding Dinner", schedule: (date + 18.hours)..(date + 20.hours), place:)
+    wedding.events << FactoryBot.build(:event, name: "Dance Party", schedule: (date + 20.hours)..(date + 24.hours), place:)
+
+    wedding
+  end
+
+  def self.place
+    FactoryBot.build(
+      :place,
+      name: "Parador de Plasencia",
+      address: FactoryBot.build(
+        :address,
+        street: "Plaza San Vicente Ferrer, 5",
+        town: "Plasencia",
+        country: "Spain",
+        zip_code: "10600"
+      )
+    )
+  end
+
   layout "application"
 
   def default
-    wedding = FactoryBot.build(:wedding)
+    wedding = self.class.wedding
     guest = FactoryBot.build(:guest)
     render(Invitation::ShowComponent.new(wedding:, guest:))
   end

--- a/test/components/previews/invitation/show_component_preview.rb
+++ b/test/components/previews/invitation/show_component_preview.rb
@@ -4,7 +4,8 @@ class Invitation::ShowComponentPreview < ViewComponent::Preview
   def self.wedding
     date = Date.new(2024, 9, 14)
 
-    wedding = FactoryBot.build(:wedding, date:)
+    wedding = FactoryBot.build(:wedding, date:, guests: FactoryBot.build_list(:guest, 1))
+    place = FactoryBot.build(:place, name: "Parador de Plasencia")
 
     wedding.events << FactoryBot.build(:event, name: "Welcome Cocktail", schedule: (date + 15.hours)..(date + 17.hours), place:)
     wedding.events << FactoryBot.build(:event, name: "Engagement Ceremony", schedule: (date + 17.hours)..(date + 18.hours), place:)
@@ -32,7 +33,7 @@ class Invitation::ShowComponentPreview < ViewComponent::Preview
 
   def default
     wedding = self.class.wedding
-    guest = FactoryBot.build(:guest)
+    guest = wedding.guests.first
     render(Invitation::ShowComponent.new(wedding:, guest:))
   end
 end

--- a/test/decorators/event_decorator_test.rb
+++ b/test/decorators/event_decorator_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventDecoratorTest < ActiveSupport::TestCase
+  setup do
+    time_range = Time.zone.local(2021, 1, 1, 12, 0, 0)..Time.zone.local(2021, 1, 1, 13, 0, 0)
+    event = FactoryBot.build(:event, schedule: time_range)
+    @event_decorator = EventDecorator.new(event)
+  end
+
+  test "#start_time returns event start time in hh:mm format" do
+    assert_equal "12:00", @event_decorator.start_time
+  end
+end

--- a/test/decorators/events_group_decorator_test.rb
+++ b/test/decorators/events_group_decorator_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventsGroupDecoratorTest < ActiveSupport::TestCase
+  setup do
+    time_range = Time.zone.local(2021, 1, 1, 12, 0, 0)..Time.zone.local(2021, 1, 1, 13, 0, 0)
+
+    wedding = FactoryBot.build(
+      :wedding,
+      guests: FactoryBot.build_list(:guest, 2),
+      events: [
+        FactoryBot.build(
+          :event,
+          schedule: time_range,
+          place: FactoryBot.build(
+            :place,
+            name: "Place name",
+            address: FactoryBot.build(
+              :address,
+              street: "Street name",
+              town: "Town name",
+              zip_code: "Zip code",
+              country: "Country name"
+            )
+          )
+        )
+      ]
+    )
+
+    @event_group_decorator = EventsGroupDecorator.new(
+      Schedule.new(wedding:, guest: wedding.guests.first).event_groups.first
+    )
+  end
+
+  test "#abbreviated_start_month returns starting event start month" do
+    assert_equal "Jan", @event_group_decorator.abbreviated_start_month
+  end
+
+  test "#full_address returns event group place complete address" do
+    assert_equal "Street name, Town name, Zip code, Country name", @event_group_decorator.full_address
+  end
+
+  test "#place_name returns event group place name" do
+    assert_equal "Place name", @event_group_decorator.place_name
+  end
+
+  test "#start_day returns starting event start day" do
+    assert_equal 1, @event_group_decorator.start_day
+  end
+end


### PR DESCRIPTION
Uses new `Schedule` model to extract `Wedding` `Events` information for `Guests`, and displays this information in invitation UI:

<img width="317" alt="Screenshot 2024-01-24 at 17 16 32" src="https://github.com/AlbertoHdezCerezo/wedding-planner/assets/9349554/f5e5a21d-fe2a-440d-896c-a043a25ca217">
