### PR TITLE
feature: guest invitation

### DIFF
--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -3,6 +3,7 @@
 class Guest < ApplicationRecord
   # Associations
   belongs_to :wedding, optional: false
+  belongs_to :invitation, optional: true
   has_many :event_guests, dependent: :destroy
   has_many :events, through: :event_guests
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
 class Invitation < ApplicationRecord
+  # Associations
   belongs_to :wedding, optional: false
+  has_many :guests, dependent: :nullify
+
+  # Validations
+  validates :guests, length: { minimum: 1 }
+  validate :guests_in_wedding_guests_list, if: -> { wedding.present? }
+
+  private
+
+  def guests_in_wedding_guests_list
+    uninvited_guests = guests.reject { wedding.in_guests_list?(_1) }
+
+    return if uninvited_guests.empty?
+
+    errors.add(:guests, :guest_not_invited_to_wedding)
+    uninvited_guests.each { _1.errors.add(:guests, :guest_not_invited_to_wedding) }
+  end
 end

--- a/db/migrate/20240124171838_add_invitation_reference_to_guests.rb
+++ b/db/migrate/20240124171838_add_invitation_reference_to_guests.rb
@@ -1,0 +1,5 @@
+class AddInvitationReferenceToGuests < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :guests, :invitation, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_23_150809) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_171838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_23_150809) do
     t.string "name", null: false
     t.string "surname", null: false
     t.string "country", null: false
+    t.uuid "invitation_id"
+    t.index ["invitation_id"], name: "index_guests_on_invitation_id"
     t.index ["wedding_id"], name: "index_guests_on_wedding_id"
   end
 
@@ -162,6 +164,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_23_150809) do
   add_foreign_key "event_services", "services", name: "service_fk_in_event_services"
   add_foreign_key "events", "places"
   add_foreign_key "events", "weddings", name: "wedding_fk_in_events"
+  add_foreign_key "guests", "invitations"
   add_foreign_key "guests", "weddings"
   add_foreign_key "invitations", "weddings"
   add_foreign_key "menu_dishes", "dishes", name: "menu_dish_fk_in_dish"

--- a/lib/factories/invitations.rb
+++ b/lib/factories/invitations.rb
@@ -2,7 +2,14 @@
 
 FactoryBot.define do
   factory :invitation do
-    association :wedding
-    guests { build_list(:guest, 1, wedding:) }
+    # For +Invitation+ factory to create invitations with +Guests+ being part
+    # of +Wedding+ +Guests+ list we need to previously create both records
+    transient do
+      sample_guest { create(:guest) }
+      sample_wedding { create(:wedding, guests: [sample_guest]) }
+    end
+
+    wedding { sample_wedding }
+    guests { [sample_guest] }
   end
 end

--- a/lib/factories/invitations.rb
+++ b/lib/factories/invitations.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :invitation do
     association :wedding
+    guests { build_list(:guest, 1, wedding:) }
   end
 end

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -3,11 +3,30 @@
 require "test_helper"
 
 class InvitationTest < ActiveSupport::TestCase
-  # Constraints
-  test "an invitation must belong to a wedding" do
+  # Validations
+  test "validates invitation belongs to wedding" do
     invitation = FactoryBot.create(:invitation)
     invitation.wedding = nil
 
     assert_not invitation.valid?, "Expected invitation without wedding to be invalid. Invitation is valid"
+  end
+
+  test "validates invitation has at least one guest" do
+    invitation = FactoryBot.build(:invitation)
+    invitation.guests = []
+
+    assert_not invitation.valid?, "Expected invitation without guests to be invalid. Invitation is valid"
+    assert invitation.errors.of_kind?(:guests, :too_short)
+  end
+
+  test "validates invitation guests are in wedding guests list" do
+    invitation = FactoryBot.build(:invitation)
+    guest = FactoryBot.create(:guest)
+    invitation.guests = [guest]
+
+    assert_not invitation.valid?, <<-SQL.squish
+      Expected invitation with guest not in wedding guests list to be invalid. Invitation is valid"
+    SQL
+    assert invitation.errors.of_kind?(:guests, :guest_not_invited_to_wedding)
   end
 end


### PR DESCRIPTION
Adds association between `Invitation` and `Guests` with corresponding validations:

- An `Invitation` has at least one `Guest`.
- `Invitation` `Guests` belong to the `Invitation` `Wedding`.