### PR TITLE
fix: icon size

### DIFF
--- a/app/components/common/icon_component.rb
+++ b/app/components/common/icon_component.rb
@@ -22,7 +22,11 @@ module Common
     end
 
     def call
-      inline_svg_tag(svg_file, **content_tag_arguments)
+      # +inline_svg_tag+ requires data attribute to be passed as a hash
+      # We perform a minor convertion of all +data-+ attributes to a hash
+      data_argument = Html::Attribute.build(content_tag_arguments, name: "data")
+
+      inline_svg_tag(svg_file, **content_tag_arguments.merge(data_argument.to_h))
     end
 
     protected


### PR DESCRIPTION
Icons were not being displayed with the right size. The problem was due to the `inline_svg_tag` helper not being able to handle flattened data attributes (for example "data-size"). Instead, the method only accepts a single `data` attribute as `Hash`.

This fix reverts the flattening of data attributes made by the `Html::Attributes` model, ensuring the data is passed in a compatible format.