### PR TITLE
chore: add `Decoratable` concern

### DIFF
--- a/app/components/invitation/envelop.html.haml
+++ b/app/components/invitation/envelop.html.haml
@@ -8,7 +8,7 @@
     - options = options.with_stimulus_action("click", stimulus_identifier, "open")
     %div{ options.to_h }
       = image_tag("invitation/stamp_01.png", alt: "stamp", class: "absolute top-10 right-8 h-[10%] md:h-[15%] w-auto rotate-6")
-      %p{ class: "absolute left-10 md:left-16 bottom-8 md:bottom-16 text-xl md:text-2xl opacity-60 uppercase tracking-[.3em]" } Maik & Mirah
+      %p{ class: "absolute left-10 md:left-16 bottom-8 md:bottom-16 text-xl md:text-2xl opacity-60 uppercase tracking-[.3em]" }= invitation.decorator.guest_names
 
     -# Back Card Face
     %div{ style: "backface-visibility: hidden; transform: rotateY(180deg)" }

--- a/app/components/invitation/pages/schedule.html.haml
+++ b/app/components/invitation/pages/schedule.html.haml
@@ -4,7 +4,7 @@
 
     -# Events list
     .mt-12
-      - schedule_decorator.event_group_decorators.each do |event_group_decorator|
+      - schedule.decorator.event_group_decorators.each do |event_group_decorator|
         %div{ class: "flex flex-row justify-between items-center pb-6 border-b-[1px] border-gray-200" }
           %p{ class: "w-[50px] font-newsreader uppercase text-center text-gray-700" }
             %span.text-xs= event_group_decorator.abbreviated_start_month

--- a/app/components/invitation/pages/schedule.rb
+++ b/app/components/invitation/pages/schedule.rb
@@ -7,10 +7,7 @@ class Invitation::Pages::Schedule < Invitation::Pages::Page
 
   def initialize(invitation:, **system_arguments)
     @invitation = invitation
-    # TODO: obviously there is some incompatibility between schedule and invitation we need to fix
-    # TODO: figure out a proper way to handle decorators
     @schedule = Schedule.new(wedding: invitation.wedding, guest: invitation.guests.first)
-    @schedule_decorator = ScheduleDecorator.new(@schedule)
     super(**system_arguments)
   end
 end

--- a/app/components/invitations/index_component.html.haml
+++ b/app/components/invitations/index_component.html.haml
@@ -27,7 +27,7 @@
                                  button_label: t(".empty.invitations.add"),
                                  button_path: new_wedding_invitation_path(wedding),
                                  button_arguments: { "data-turbo-frame": "modal" })
-      - table.with_column(t(".table.guests")) { tag.p("#{_1.guests.pluck(:name).join(", ")}") }
+      - table.with_column(t(".table.guests")) { tag.p(_1.decorator.guest_names) }
       - table.with_column(t(".table.url")) { link_to("link to invitation", invitation_path(_1), target: "_blank") }
       - table.with_column(t(".table.status")) { tag.p("Not Sent") }
       - table.with_column(horizontal_alignment: :right) do |invitation|
@@ -47,4 +47,3 @@
                                     scheme: :secondary,
                                     href: edit_wedding_invitation_path(wedding, invitation),
                                     "data-turbo-frame": "modal")
-

--- a/app/decorators/guest_decorator.rb
+++ b/app/decorators/guest_decorator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class GuestDecorator < ApplicationDecorator
+  def full_name = "#{name} #{surname}"
+end

--- a/app/decorators/invitation_decorator.rb
+++ b/app/decorators/invitation_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class InvitationDecorator < ApplicationDecorator
+  def guest_names = join_full_names(guest_decorators.map(&:full_name))
+
+  def guest_decorators = @guest_decorators ||= guests.map { GuestDecorator.new(_1) }
+
+  private
+
+  def join_full_names(names)
+    if names.is_a?(Array)
+      names.size > 2 ? "#{names[0..-3].join(", ")}, #{join_full_names(names[-2..])}" : names.join(" & ")
+    else
+      names
+    end
+  end
+end

--- a/app/models/concerns/decoratable.rb
+++ b/app/models/concerns/decoratable.rb
@@ -1,12 +1,14 @@
 
 module Decoratable
+  class DecoratorNoDefinedError < StandardError; end
+
   extend ActiveSupport::Concern
 
   included do
     def decorator
       @decorator ||= "#{self.class.name}Decorator".constantize.new(self)
     rescue NameError
-      raise <<-EXCEPTION
+      raise DecoratorNoDefinedError, <<-EXCEPTION
         There is no #{self.class.name}Decorator class defined for #{self.class.name} model.
       EXCEPTION
     end

--- a/app/models/concerns/decoratable.rb
+++ b/app/models/concerns/decoratable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Decoratable
   class DecoratorNoDefinedError < StandardError; end

--- a/app/models/concerns/decoratable.rb
+++ b/app/models/concerns/decoratable.rb
@@ -1,0 +1,14 @@
+
+module Decoratable
+  extend ActiveSupport::Concern
+
+  included do
+    def decorator
+      @decorator ||= "#{self.class.name}Decorator".constantize.new(self)
+    rescue NameError
+      raise <<-EXCEPTION
+        There is no #{self.class.name}Decorator class defined for #{self.class.name} model.
+      EXCEPTION
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  include Decoratable
+
   # Associations
   belongs_to :wedding
   belongs_to :place, optional: true

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Invitation < ApplicationRecord
+  include Decoratable
+
   # Associations
   belongs_to :wedding, optional: false
   has_many :guests, dependent: :nullify

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Place < ApplicationRecord
+  include Decoratable
+
   # Associations
   belongs_to :address, dependent: :destroy
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -3,6 +3,8 @@
 class Schedule
   # Set of +Wedding+ +Events+ taking place at the same place, sorted by time
   class EventsGroup
+    include Decoratable
+
     attr_reader :wedding, :events, :place
 
     def initialize(wedding:, place:)
@@ -15,6 +17,8 @@ class Schedule
 
     def time_range = events.first.schedule.begin..events.last.schedule.end
   end
+
+  include Decoratable
 
   attr_reader :wedding, :guest
 

--- a/test/decorators/guest_decorator_test.rb
+++ b/test/decorators/guest_decorator_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventDecoratorTest < ActiveSupport::TestCase
+  setup do
+    @guest = FactoryBot.build(:guest, name: "John", surname: "Doe")
+    @guest_decorator = GuestDecorator.new(@guest)
+  end
+
+  test "#full_name returns guest name & surname" do
+    assert_equal "John Doe", @guest_decorator.full_name
+  end
+end

--- a/test/decorators/invitation_decorator_test.rb
+++ b/test/decorators/invitation_decorator_test.rb
@@ -36,4 +36,3 @@ class InvitationDecoratorTest < ActiveSupport::TestCase
     assert_equal "John Doe, Jane Doe & Jack Doe", invitation_decorator.guest_names
   end
 end
-

--- a/test/decorators/invitation_decorator_test.rb
+++ b/test/decorators/invitation_decorator_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InvitationDecoratorTest < ActiveSupport::TestCase
+  setup do
+    @wedding = FactoryBot.create(:wedding)
+    @guests = [
+      FactoryBot.create(:guest, name: "John", surname: "Doe", wedding: @wedding),
+      FactoryBot.create(:guest, name: "Jane", surname: "Doe", wedding: @wedding),
+      FactoryBot.create(:guest, name: "Jack", surname: "Doe", wedding: @wedding)
+    ]
+  end
+
+  test "#guest_names if invitation has one guest,
+                returns guest full name" do
+    invitation = FactoryBot.create(:invitation, wedding: @wedding, guests: [@guests[0]])
+    invitation_decorator = InvitationDecorator.new(invitation)
+
+    assert_equal "John Doe", invitation_decorator.guest_names
+  end
+
+  test "#guest_names if invitation has two guest,
+                returns guests' full name joint by &" do
+    invitation = FactoryBot.create(:invitation, wedding: @wedding, guests: @guests[0..1])
+    invitation_decorator = InvitationDecorator.new(invitation)
+
+    assert_equal "John Doe & Jane Doe", invitation_decorator.guest_names
+  end
+
+  test "#guest_names if invitation more than two guest,
+                returns guests' full name joint by commas, except last ones, joint by &" do
+    invitation = FactoryBot.create(:invitation, wedding: @wedding, guests: @guests)
+    invitation_decorator = InvitationDecorator.new(invitation)
+
+    assert_equal "John Doe, Jane Doe & Jack Doe", invitation_decorator.guest_names
+  end
+end
+

--- a/test/models/concerns/decoratable_test.rb
+++ b/test/models/concerns/decoratable_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DecoratableTest < ActiveSupport::TestCase
+  class DecoratableModel
+    include Decoratable
+  end
+
+  class DecoratableModelDecorator < ApplicationDecorator
+  end
+
+  class NonDecoratableModel
+    include Decoratable
+  end
+
+  test "#decorator returns model decorator" do
+    model = DecoratableModel.new
+    decorator = model.decorator
+
+    assert_kind_of DecoratableModelDecorator, decorator
+    assert_equal model, decorator.__getobj__
+  end
+
+  test "#decorator if model has no decorator defined, raises exception" do
+    model = NonDecoratableModel.new
+
+    assert_raises(Decoratable::DecoratorNoDefinedError) { model.decorator }
+  end
+end


### PR DESCRIPTION
Defines a `decorator` method for the `ApplicationRecord` classes in which it is included. The method infers the corresponding model decorator from its class name and creates an instance of it, stored in a local attribute.

This way we can easily switch from model instances to its decorators in views.