### PR TITLE
feature: invitation state machine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,8 @@ gem "money-rails", "~> 1.15"
 
 # State-Machine logic for Ruby, compatible with ActiveRecord
 # https://github.com/state-machines/state_machines
-gem "aasm", "~> 5.3.0"
+gem "aasm", "5.1.0"
+gem "after_commit_everywhere", "~> 1.3.0"
 
 group :development, :test do
   # powerful component browser and preview system with an integrated documentation engine

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem "money-rails", "~> 1.15"
 # State-Machine logic for Ruby, compatible with ActiveRecord
 # https://github.com/state-machines/state_machines
 gem "aasm", "5.1.0"
+
+# Allows defining ActiveRecord callbacks anywhere outside of Model classes
+# https://github.com/Envek/after_commit_everywhere
 gem "after_commit_everywhere", "~> 1.3.0"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,10 @@ gem "dry-schema", "~> 1.13.3"
 # https://github.com/RubyMoney/money-rails
 gem "money-rails", "~> 1.15"
 
+# State-Machine logic for Ruby, compatible with ActiveRecord
+# https://github.com/state-machines/state_machines
+gem "state_machines", "~> 0.6.0"
+
 group :development, :test do
   # powerful component browser and preview system with an integrated documentation engine
   gem "lookbook", ">= 2.0.5"

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "money-rails", "~> 1.15"
 
 # State-Machine logic for Ruby, compatible with ActiveRecord
 # https://github.com/state-machines/state_machines
-gem "state_machines", "~> 0.6.0"
+gem "aasm", "~> 5.3.0"
 
 group :development, :test do
   # powerful component browser and preview system with an integrated documentation engine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.3.1)
+      concurrent-ruby (~> 1.0)
     actioncable (7.1.3)
       actionpack (= 7.1.3)
       activesupport (= 7.1.3)
@@ -331,7 +333,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    state_machines (0.6.0)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -374,6 +375,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aasm (~> 5.3.0)
   bootsnap
   capybara
   cssbundling-rails (~> 1.4)
@@ -401,7 +403,6 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 6.1)
   sprockets-rails
-  state_machines (~> 0.6.0)
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.3.1)
+    aasm (5.1.0)
       concurrent-ruby (~> 1.0)
     actioncable (7.1.3)
       actionpack (= 7.1.3)
@@ -79,6 +79,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    after_commit_everywhere (1.3.1)
+      activerecord (>= 4.2)
+      activesupport
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
@@ -375,7 +378,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  aasm (~> 5.3.0)
+  aasm (= 5.1.0)
+  after_commit_everywhere (~> 1.3.0)
   bootsnap
   capybara
   cssbundling-rails (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    state_machines (0.6.0)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -400,6 +401,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 6.1)
   sprockets-rails
+  state_machines (~> 0.6.0)
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,6 +2,7 @@
 
 class Invitation < ApplicationRecord
   include Decoratable
+  include AASM
 
   # Associations
   belongs_to :wedding, optional: false
@@ -10,6 +11,32 @@ class Invitation < ApplicationRecord
   # Validations
   validates :guests, length: { minimum: 1 }
   validate :guests_in_wedding_guests_list, if: -> { wedding.present? }
+
+  # State Machine
+  aasm column: :state, timestamps: false do
+    state :pending, initial: true
+    state :sent, :opened, :accepted, :declined, :cancelled
+
+    event :deliver do
+      transitions from: :pending, to: :sent
+    end
+
+    event :open do
+      transitions from: :sent, to: :opened
+    end
+
+    event :accept do
+      transitions from: :opened, to: :accepted
+    end
+
+    event :decline do
+      transitions from: :opened, to: :declined
+    end
+
+    event :cancel do
+      transitions from: :accepted, to: :cancelled
+    end
+  end
 
   private
 

--- a/db/migrate/20240131164130_add_state_to_invitations.rb
+++ b/db/migrate/20240131164130_add_state_to_invitations.rb
@@ -1,5 +1,5 @@
 class AddStateToInvitations < ActiveRecord::Migration[7.1]
   def change
-    add_column :invitations, :state, :string, null: false, default: "created"
+    add_column :invitations, :state, :string, null: false, default: "pending"
   end
 end

--- a/db/migrate/20240131164130_add_state_to_invitations.rb
+++ b/db/migrate/20240131164130_add_state_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddStateToInvitations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invitations, :state, :string, null: false, default: "created"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_171838) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_31_164130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_171838) do
     t.uuid "wedding_id", null: false
     t.timestamptz "created_at", precision: 6, null: false
     t.timestamptz "updated_at", precision: 6, null: false
+    t.string "state", default: "pending", null: false
     t.index ["wedding_id"], name: "index_invitations_on_wedding_id"
   end
 

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -35,7 +35,7 @@ class InvitationTest < ActiveSupport::TestCase
   test "by default an invitation state is pending" do
     invitation = FactoryBot.create(:invitation)
 
-    assert invitation.pending?, <<-MESSAGE
+    assert_predicate invitation, :pending?, <<-MESSAGE
       Expected new invitation to have pending state by default. Invitation has #{invitation.state} state
     MESSAGE
   end


### PR DESCRIPTION
Extends `Invitation` model with a new `state` attribute, and defines a state-machine logic via the `aasm` gem to track the state of the invitation.

We define an invitation life-flow consisting of these states:

pending -> sent -> opened -> accepted -> cancelled
                                               -> declined

This way we can track better which guests are attending to the event.