### PR TITLE
feature: invitation state transitions

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -4,6 +4,12 @@ class Invitation < ApplicationRecord
   include Decoratable
   include AASM
 
+  # TODO: if used more often, move it to a concern
+  def self.state_machine_events = self.aasm.events.map(&:name)
+
+  def compatible_events = aasm.events(permitted: true).map(&:name)
+  # -----
+
   # Associations
   belongs_to :wedding, optional: false
   has_many :guests, dependent: :nullify
@@ -13,7 +19,7 @@ class Invitation < ApplicationRecord
   validate :guests_in_wedding_guests_list, if: -> { wedding.present? }
 
   # State Machine
-  aasm column: :state, timestamps: false do
+  aasm column: :state, timestamps: false, whiny_persistence: false do
     state :pending, initial: true
     state :sent, :opened, :accepted, :declined, :cancelled
 

--- a/app/models/invitation_state_transition.rb
+++ b/app/models/invitation_state_transition.rb
@@ -1,0 +1,38 @@
+class InvitationStateTransition
+  include ActiveModel::Validations
+
+  attr_reader :event, :invitation
+
+  def initialize(event:, invitation:)
+    @event = event
+    @invitation = invitation
+  end
+
+  validates :event, presence: true
+  validates :invitation, presence: true
+  validate :event_is_defined, if: -> { event.present? }
+  validate :invitation_state_compatible_with_event, if: -> { invitation.present? && event.present? }
+
+  def save
+    return false if invalid?
+
+    # +Invitation+ +whiny_persistence+ machine state option makes bang operator return +true+ / +false+
+    invitation.aasm.fire!(event)
+  end
+
+  private
+
+  def event_is_defined
+    return if Invitation.aasm.events.include?(event.to_sym)
+
+    errors.add(:event, :not_defined)
+  end
+
+  def invitation_state_compatible_with_event
+    compatible_events = invitation.compatible_events
+
+    return if compatible_events.include?(event.to_sym)
+
+    errors.add(:event, :incompatible_with_invitation_state)
+  end
+end

--- a/app/parameters/invitation_state_transition_parameters.rb
+++ b/app/parameters/invitation_state_transition_parameters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InvitationStateTransitionParameters < ApplicationParameters
+  Schema = Dry::Schema.Params do
+    required(:invitation_id).filled(:string)
+    required(:event).filled(:string)
+  end
+end

--- a/lib/factories/invitations.rb
+++ b/lib/factories/invitations.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     # of +Wedding+ +Guests+ list we need to previously create both records
     transient do
       sample_guest { create(:guest) }
-      sample_wedding { create(:wedding, guests: [sample_guest]) }
+      sample_wedding { sample_guest.wedding }
     end
 
     wedding { sample_wedding }

--- a/test/models/invitation_state_transition_test.rb
+++ b/test/models/invitation_state_transition_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InvitationStateTransitionTest < ActiveSupport::TestCase
+  # Validations
+  test "validates invitation presence" do
+    invitation_state_transition = InvitationStateTransition.new(invitation: nil, event: "accept")
+
+    assert_not invitation_state_transition.valid?
+    assert invitation_state_transition.errors.of_kind?(:invitation, :blank)
+  end
+
+  test "validates event presence" do
+    invitation_state_transition = InvitationStateTransition.new(invitation: FactoryBot.build(:invitation), event: nil)
+
+    assert_not invitation_state_transition.valid?
+    assert invitation_state_transition.errors.of_kind?(:event, :blank)
+  end
+
+  test "if event is present, validates event is registered" do
+    invitation_state_transition = InvitationStateTransition.new(
+      invitation: FactoryBot.build(:invitation),
+      event: "unregistered_event"
+    )
+
+    assert_not invitation_state_transition.valid?
+    assert invitation_state_transition.errors.of_kind?(:event, :not_defined)
+  end
+
+  test "if invitation cannot process event in current state, validates event incompatibility with state" do
+    invitation_state_transition = InvitationStateTransition.new(
+      invitation: FactoryBot.build(:invitation, state: :pending),
+      event: "unregistered_event"
+    )
+
+    assert_not invitation_state_transition.valid?
+    assert invitation_state_transition.errors.of_kind?(:event, :incompatible_with_invitation_state)
+  end
+
+  test "#save if invitation state transition is valid, transitions invitation state with given event" do
+    guest = FactoryBot.create(:guest)
+    invitation = FactoryBot.create(:invitation, wedding: guest.wedding, guests: [guest], state: :pending)
+    invitation_state_transition = InvitationStateTransition.new(invitation:, event: :deliver)
+
+    assert_changes -> { invitation.reload.state }, to: "sent" do
+      assert invitation_state_transition.save
+    end
+  end
+
+  test "#save if invitation state transition is invalid, invitation state does not change" do
+    guest = FactoryBot.create(:guest)
+    invitation = FactoryBot.create(:invitation, wedding: guest.wedding, guests: [guest], state: :pending)
+    invitation_state_transition = InvitationStateTransition.new(invitation:, event: :invalid_event)
+
+    assert_no_changes -> { invitation.reload.state } do
+      assert_not invitation_state_transition.save
+    end
+  end
+end

--- a/test/parameters/invitation_state_transition_parameters_test.rb
+++ b/test/parameters/invitation_state_transition_parameters_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InvitationStateTransitionParametersTest < ActiveSupport::TestCase
+  test "parses invitation state transition permitted parameters" do
+    params = ActionController::Parameters.new(permitted_parameters)
+
+    parsed_params = InvitationStateTransitionParameters.new(params)
+
+    assert_equal permitted_parameters.keys, parsed_params.keys
+  end
+
+  test "filters invitation state transition unpermitted parameters" do
+    params = ActionController::Parameters.new(unpermitted_parameters)
+
+    parsed_params = InvitationStateTransitionParameters.new(params)
+
+    assert_empty parsed_params
+  end
+
+  private
+
+  def permitted_parameters
+    {
+      invitation_id: "invitation_id",
+      event: "open"
+    }
+  end
+
+  def unpermitted_parameters
+    {
+      unpermitted_parameter: false,
+      other_unpermitted_parameter: false
+    }
+  end
+end


### PR DESCRIPTION
Implements a `Service` `Object` which encapsulates the logic for transitioning between `Invitation` states. This can be then used in controllers to trigger those events when the user performs certain actions in the UI.