### PR TITLE
feature: Opening Event

### DIFF
--- a/app/models/wedding.rb
+++ b/app/models/wedding.rb
@@ -2,6 +2,8 @@
 
 class Wedding < ApplicationRecord
   # Associations
+  has_one :opening_event, required: false, class_name: "Event", dependent: :nullify
+
   has_many :events, dependent: :destroy
   has_many :guests, dependent: :destroy
   has_many :services, dependent: :destroy
@@ -10,8 +12,15 @@ class Wedding < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :date, presence: true, comparison: { greater_than: Date.current }
+  validate :opening_event_in_events, if: -> { opening_event_id.present? }
 
   def in_guests_list?(guest) = guests.include?(guest)
 
   def days_left = (date - Date.current).to_i
+
+  private
+
+  def opening_event_in_events
+    errors.add(:opening_event_id, :unknown_wedding_event) unless events.exists?(opening_event_id)
+  end
 end

--- a/db/migrate/20240209084742_add_opening_event_to_weddings.rb
+++ b/db/migrate/20240209084742_add_opening_event_to_weddings.rb
@@ -1,0 +1,5 @@
+class AddOpeningEventToWeddings < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :weddings, :opening_event, null: true, type: :uuid, foreign_key: { to_table: :events, name: "opening_event_fk_in_weddings" }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_31_164130) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_09_084742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -156,6 +156,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_31_164130) do
     t.timestamptz "created_at", precision: 6, null: false
     t.timestamptz "updated_at", precision: 6, null: false
     t.string "name", null: false
+    t.uuid "opening_event_id"
+    t.index ["opening_event_id"], name: "index_weddings_on_opening_event_id"
   end
 
   add_foreign_key "dishes", "organizations", name: "dish_fk_in_organization"
@@ -175,4 +177,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_31_164130) do
   add_foreign_key "offers", "services", name: "offer_fk_in_service"
   add_foreign_key "places", "addresses"
   add_foreign_key "services", "weddings", name: "wedding_fk_in_services"
+  add_foreign_key "weddings", "events", column: "opening_event_id", name: "opening_event_fk_in_weddings"
 end

--- a/test/models/wedding_test.rb
+++ b/test/models/wedding_test.rb
@@ -24,7 +24,17 @@ class WeddingTest < ActiveSupport::TestCase
     wedding = FactoryBot.build(:wedding)
     wedding.date = Date.current - 2.days
 
-    assert_not wedding.save
+    assert_not wedding.valid?
     assert wedding.errors.of_kind?(:date, :greater_than)
+  end
+
+  test "if opening event is selected, validates it belongs to Wedding events" do
+    wedding = FactoryBot.build(:wedding, :with_events)
+    opening_event = FactoryBot.create(:event)
+
+    wedding.opening_event_id = opening_event.id
+
+    assert_not wedding.valid?
+    assert wedding.errors.of_kind?(:opening_event_id, :unknown_wedding_event)
   end
 end


### PR DESCRIPTION
Adds new `Event` `has_one` association to `Weddings` to model the `opening_event`. This event represents the starting point of your ceremony, and its information is what will be displayed in the invitation.