### PR TITLE
feature: phone invitation pages

### DIFF
--- a/app/components/invitation/card_controller.js
+++ b/app/components/invitation/card_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { Navigator } from '../../javascript/src/invitation/navigator'
 import { Animator } from '../../javascript/src/invitation/animator'
+import { DeviceRecognizer } from '../../javascript/src/lib/deviceRecognizer'
 
 const MENU_REVEAL_ANIMATION = {
   autoplay: false,
@@ -37,20 +38,10 @@ export default class extends Controller {
 
     this.navigateTo({
       currentTarget: this.menuButtons[0],
-      params: { pageName: this.#renderedInPhone() ? 'cover' : 'welcome' }
+      params: { pageName: DeviceRecognizer.isMobile() ? 'cover' : 'welcome' }
     })
 
     this.dispatch('connected', { detail: { controller: this } })
-  }
-
-  /**
-   * Returns true if card is rendered in a mobile device. Phone devices
-   * have a width of less than 680px, the breakpoint width used by
-   * tailwindCSS to differentiate between phones and tables
-   * @returns {boolean}
-   */
-  #renderedInPhone () {
-    return window.innerHeight <= 680
   }
 
   async revealMenu () {

--- a/app/components/invitation/pages/welcome_phone.html.haml
+++ b/app/components/invitation/pages/welcome_phone.html.haml
@@ -1,0 +1,36 @@
+= render(Invitation::Layout::PageComponent.new(**content_tag_arguments)) do
+  .h-full.w-full.relative.flex.flex-col.items-center.justify-center.px-6.py-10.text-gray-700
+    %hr.absolute.left-0.my-auto.border-gray-200{ class: "w-[20%]" }
+    %hr.absolute.right-0.my-auto.border-gray-200{ class: "w-[20%]" }
+
+    %h1.absolute.px-16.m-auto.font-ambrosia.text-8xl.text-gray-500.space-y-4
+      %p{ class: "leading-[0.6]" } 14
+      %p{ class: "leading-[0.6]" } 09
+
+    %h2.absolute.uppercase.text-xs.space-x-1.text-gray-500{ class: "text-[10px] bottom-[120px] tracking-[.1em]" }
+      %span= t(".save_the_date")
+      %span •
+      %span Alberto & Andrea2
+
+    - unless invitation.accepted?
+      - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
+      %div{ options.to_h }
+        -# Options before invitation is accepted
+        = form_with(model: invitation_state_transition,
+                    url: invitation_state_transition_url,
+                    method: :post,
+                    builder: ComponentFormBuilder,
+                    data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#greetConfirmedGuest" }) do |form|
+          = form.hidden_field :event, value: "accept"
+          = form.hidden_field :invitation_id, value: @invitation.id
+
+          - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
+                                                    class: "!w-[60%] absolute left-1/2 transform -translate-x-1/2 bottom-16" })
+          - options = options.with_stimulus_target("confirmationButton", stimulus_identifier)
+          = invitation_button_component(**options.to_h)
+
+    -# Options after invitation is accepted
+    - options = ::Html::TagAttributes.build({ label: t(".add_to_calendar"), size: :small, scheme: :secondary,
+                                              class: "#{ "hidden opacity-0" unless invitation.accepted? || preview_mode } !w-[60%] bottom-16 absolute margin-auto" })
+    - options = options.with_stimulus_target("afterAccept", stimulus_identifier)
+    = invitation_button_component(tag: :a, href: calendar_url, **options.to_h)

--- a/app/components/invitation/pages/welcome_phone.rb
+++ b/app/components/invitation/pages/welcome_phone.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::WelcomePhone < Invitation::Pages::Page
+  def self.page_name = "welcome-phone"
+
+  attr_reader :invitation, :invitation_state_transition
+
+  def initialize(invitation:, preview_mode: false, **system_arguments)
+    @invitation = invitation
+    @preview_mode = preview_mode
+    @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
+    super(**system_arguments)
+  end
+
+  private
+
+  def calendar_url
+    ::AddToCalendar::URLs.new(
+      # TODO: we need to specify a time for the event
+      start_datetime: invitation.wedding.date.to_time,
+      title: invitation.wedding.name,
+      description: "Party!!!",
+      all_day: true,
+      url: request.original_url,
+      timezone: "Europe/London"
+    ).ical_url
+  end
+
+  def default_content_tag_arguments
+    options = ::Html::TagAttributes.build(super)
+    options = options.with_stimulus_controller(stimulus_identifier)
+    options.to_h
+  end
+end

--- a/app/components/invitation/pages/welcome_phone.yml
+++ b/app/components/invitation/pages/welcome_phone.yml
@@ -1,0 +1,9 @@
+en:
+  save_the_date: Save the date
+  accept: accept invitation
+  add_to_calendar: add event to calendar
+
+es:
+  save_the_date: Reserva la fecha
+  accept: aceptar invitación
+  add_to_calendar: añadir evento a tu calendario

--- a/app/components/invitation/show_component_controller.js
+++ b/app/components/invitation/show_component_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { Animator } from '../../javascript/src/invitation/animator'
+import { DeviceRecognizer } from '../../javascript/src/lib/deviceRecognizer'
 
 const REVEAL_ENVELOP_ANIMATIONS = [
   {
@@ -41,14 +42,10 @@ export default class extends Controller {
      * For mobile devices ensure layout fits the window boundaries and not
      * the screen limits (so the navigation bar, for example, is excluded)
      */
-    if (this.#mobileDevice()) {
+    if (DeviceRecognizer.isMobile()) {
       this.element.style.width = `${window.innerWidth}px`
       this.element.style.height = `${window.innerHeight}px`
     }
-  }
-
-  #mobileDevice () {
-    return window.innerWidth <= 680
   }
 
   registerEnvelopController ({ detail: { controller: envelopController } }) {

--- a/app/javascript/src/invitation/navigator.js
+++ b/app/javascript/src/invitation/navigator.js
@@ -1,4 +1,5 @@
 import { Animator } from './animator'
+import { DeviceRecognizer } from '../lib/deviceRecognizer'
 
 const ATTACH_ANIMATION = {
   autoplay: false,
@@ -83,8 +84,27 @@ export class Navigator {
     this.attachmentTarget = attachmentTarget
   }
 
+  /**
+   * By prefixing a page name with '-phone' the Navigator will try to find
+   * a page with the same name but with the '-phone' suffix. Use this when
+   * you want to define different page layouts for mobile and desktop.
+   * @param name
+   * @returns {string}
+   */
+  #phonePageName (name) {
+    return `${name}-phone`
+  }
+
   page (name) {
-    return this.pages.find((page) => page.name === name)
+    let page = null
+
+    if (DeviceRecognizer.isMobile()) {
+      console.log(this.#phonePageName(name))
+      page = this.pages.find((page) => page.name === this.#phonePageName(name))
+      console.log(page)
+    }
+
+    return page || this.pages.find((page) => page.name === name)
   }
 
   /**

--- a/app/javascript/src/lib/deviceRecognizer.js
+++ b/app/javascript/src/lib/deviceRecognizer.js
@@ -1,0 +1,12 @@
+// Represents an invitation page (welcome, schedule, etc).
+export class DeviceRecognizer {
+/**
+ * Returns true if page is rendered in a mobile device. Phone
+ * devices have a width of less than 680px, the breakpoint width
+ * used by tailwindCSS to differentiate between phones and tables
+ * @returns {boolean}
+ */
+  static isMobile () {
+    return window.innerHeight <= 680
+  }
+}

--- a/app/javascript/src/lib/deviceRecognizer.js
+++ b/app/javascript/src/lib/deviceRecognizer.js
@@ -7,6 +7,6 @@ export class DeviceRecognizer {
  * @returns {boolean}
  */
   static isMobile () {
-    return window.innerHeight <= 680
+    return window.innerHeight <= 915 || window.innerWidth <= 430
   }
 }


### PR DESCRIPTION
Now we can specify different layouts for regular and phone versions of the same page. The navigator will check whether the website is loaded on a phone browser or not and whether there are -phone versions of the page it is navigating to. If that is the case it will always load the phone version.