### PR TITLE
feature: phone invitation pages

### DIFF
--- a/app/components/invitation/card.html.haml
+++ b/app/components/invitation/card.html.haml
@@ -2,7 +2,7 @@
   .relative.flex.flex-row.space-x-16{ class: "border-[1.5px]" }
     -# Left side of card, hidden on phone devices
     %div{ class: "max-[600px]:hidden block" }
-      = render Invitation::Pages::Cover.new(invitation:)
+      = render Invitation::Pages::Cover.new(invitation:, preview_mode:)
 
     -# Right side of card, invitation UI (page navigation happens here)
     .contents{ stimulus_target_option("pageAttachment", self.stimulus_identifier) }
@@ -25,4 +25,4 @@
         - options = stimulus_target_option("pageTemplate", self.stimulus_identifier)
         - options.merge!(data: { page_name: page.page_name })
         %template{ options }
-          = render page.new(invitation:)
+          = render page.new(invitation:, preview_mode: false)

--- a/app/components/invitation/card.html.haml
+++ b/app/components/invitation/card.html.haml
@@ -25,4 +25,4 @@
         - options = stimulus_target_option("pageTemplate", self.stimulus_identifier)
         - options.merge!(data: { page_name: page.page_name })
         %template{ options }
-          = render page.new(invitation:, preview_mode: false)
+          = render page.new(invitation:, preview_mode:)

--- a/app/components/invitation/card.rb
+++ b/app/components/invitation/card.rb
@@ -27,7 +27,7 @@ class Invitation::Card < Invitation::ApplicationComponent
 
   def pages
     # Ignores component previews, set in the same namespace of the +Page+ components
-    Invitation::Pages.constants
+    Invitation::Pages.constants.reject { |c| c == :Common }
                      .map(&:to_s)
                      .grep_v(/(Preview|Page)\z/)
                      .map { "Invitation::Pages::#{_1}".constantize }

--- a/app/components/invitation/card.rb
+++ b/app/components/invitation/card.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Invitation::Card < Invitation::ApplicationComponent
-  attr_reader :invitation
+  attr_reader :invitation, :preview_mode
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
+    @preview_mode = preview_mode
     super(**system_arguments)
   end
 

--- a/app/components/invitation/card_controller.js
+++ b/app/components/invitation/card_controller.js
@@ -1,7 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { Navigator } from '../../javascript/src/invitation/navigator'
 import { Animator } from '../../javascript/src/invitation/animator'
-import { DeviceRecognizer } from '../../javascript/src/lib/deviceRecognizer'
 
 const MENU_REVEAL_ANIMATION = {
   autoplay: false,
@@ -38,7 +37,7 @@ export default class extends Controller {
 
     this.navigateTo({
       currentTarget: this.menuButtons[0],
-      params: { pageName: DeviceRecognizer.isMobile() ? 'cover' : 'welcome' }
+      params: { pageName: 'welcome' }
     })
 
     this.dispatch('connected', { detail: { controller: this } })

--- a/app/components/invitation/envelop.html.haml
+++ b/app/components/invitation/envelop.html.haml
@@ -18,4 +18,4 @@
 
     -# Back Card Face
     %div{ style: "backface-visibility: hidden; transform: rotateY(180deg)" }
-      = render(Invitation::Card.new(invitation:))
+      = render(Invitation::Card.new(invitation:, preview_mode:))

--- a/app/components/invitation/envelop.rb
+++ b/app/components/invitation/envelop.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Invitation::Envelop < Invitation::ApplicationComponent
-  attr_reader :invitation
+  attr_reader :invitation, :preview_mode
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
+    @preview_mode = preview_mode
     super(**system_arguments)
   end
 

--- a/app/components/invitation/letter.rb
+++ b/app/components/invitation/letter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Invitation::Letter < Invitation::ApplicationComponent
-  attr_reader :invitation
+  attr_reader :invitation, :preview_mode
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
+    @preview_mode = preview_mode
     super(**system_arguments)
   end
 

--- a/app/components/invitation/pages/common/accept_invitation_button.html.haml
+++ b/app/components/invitation/pages/common/accept_invitation_button.html.haml
@@ -1,0 +1,26 @@
+.contents{ **content_tag_arguments }
+  - unless invitation.accepted?
+    - if preview_mode
+      - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary })
+      - options = options.with_stimulus_target("beforeAccept", stimulus_identifier)
+      - options = options.with_stimulus_action("click", stimulus_identifier, "greetConfirmedGuest")
+      = invitation_button_component(**options.to_h)
+    - else
+      - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
+      %div{ options.to_h }
+        -# Options before invitation is accepted
+        = form_with(model: invitation_state_transition,
+                    url: invitation_state_transition_url,
+                    method: :post,
+                    builder: ComponentFormBuilder,
+                    data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#markInvitationAsConfirmed" }) do |form|
+          = form.hidden_field :event, value: "accept"
+          = form.hidden_field :invitation_id, value: @invitation.id
+
+          - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary })
+          = invitation_button_component(**options.to_h)
+
+      -# Options after invitation is accepted
+    - options = ::Html::TagAttributes.build({ label: t(".add_to_calendar"), size: :small, scheme: :secondary, class: "#{ "hidden opacity-0" unless invitation.accepted? }" })
+    - options = options.with_stimulus_target("afterAccept", stimulus_identifier)
+    = invitation_button_component(tag: :a, href: calendar_url, **options.to_h)

--- a/app/components/invitation/pages/common/accept_invitation_button.rb
+++ b/app/components/invitation/pages/common/accept_invitation_button.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::Common::AcceptInvitationButton < Invitation::ApplicationComponent
+  attr_reader :invitation, :invitation_state_transition, :preview_mode
+
+  def initialize(invitation:, preview_mode: false, **system_arguments)
+    @invitation = invitation
+    @preview_mode = preview_mode
+    @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
+    super(**system_arguments)
+  end
+
+  private
+
+  def calendar_url
+    ::AddToCalendar::URLs.new(
+      # TODO: we need to specify a time for the event
+      start_datetime: invitation.wedding.date.to_time,
+      title: invitation.wedding.name,
+      description: "Party!!!",
+      all_day: true,
+      url: request.original_url,
+      timezone: "Europe/London"
+    ).ical_url
+  end
+
+  def default_content_tag_arguments
+    options = ::Html::TagAttributes.build(super)
+    options = options.with_stimulus_controller(stimulus_identifier)
+    options.to_h
+  end
+end

--- a/app/components/invitation/pages/common/accept_invitation_button.yaml
+++ b/app/components/invitation/pages/common/accept_invitation_button.yaml
@@ -1,0 +1,7 @@
+en:
+  accept: accept invitation
+  add_to_calendar: add event to calendar
+
+es:
+  accept: aceptar invitación
+  add_to_calendar: añadir evento a calendario

--- a/app/components/invitation/pages/common/accept_invitation_button_controller.js
+++ b/app/components/invitation/pages/common/accept_invitation_button_controller.js
@@ -1,0 +1,67 @@
+import { Animator } from '../../../../javascript/src/invitation/animator'
+import { Controller } from '@hotwired/stimulus'
+import JSConfetti from 'js-confetti'
+
+const BEFORE_ACCEPT_ANIMATION = {
+  autoplay: false,
+  duration: 800,
+  easing: 'easeInExpo',
+  opacity: [1, 0]
+}
+
+const AFTER_ACCEPT_ANIMATION = {
+  autoplay: false,
+  duration: 800,
+  easing: 'easeInExpo',
+  opacity: [0, 1]
+}
+
+/**
+ * Small controller which listens for invitation confirmation form
+ * submission event. When the invitation is successfully confirmed,
+ * displays the button to save the event to the user's calendar.
+ */
+export default class extends Controller {
+  static targets = [
+    // Target/s whose content is displayed before the invitation is accepted
+    'beforeAccept',
+    // Target/s whose content is displayed after the invitation is accepted
+    'afterAccept'
+  ]
+
+  markInvitationAsConfirmed ({ detail: { fetchResponse } }) {
+    if (fetchResponse.succeeded) this.greetConfirmedGuest()
+  }
+
+  greetConfirmedGuest () {
+    console.log('me llama')
+    this.#throwConfetti()
+    this.#switchConfirmAndCalendarButtons()
+  }
+
+  async #throwConfetti () {
+    const confetti = new JSConfetti()
+    await confetti.addConfetti({ emojis: ['🔔', '💒', '🥂', '✨', '💍', '🍾'] })
+    confetti.clearCanvas()
+  }
+
+  async #switchConfirmAndCalendarButtons () {
+    await Animator.play(
+      Animator.animation({
+        targets: this.beforeAcceptTarget,
+        ...BEFORE_ACCEPT_ANIMATION
+      })
+    )
+
+    // Remove the before-accept content from the DOM and reveal the after-accept content
+    this.beforeAcceptTarget.remove()
+    this.afterAcceptTarget.classList.remove('hidden')
+
+    await Animator.play(
+      Animator.animation({
+        targets: this.afterAcceptTarget,
+        ...AFTER_ACCEPT_ANIMATION
+      })
+    )
+  }
+}

--- a/app/components/invitation/pages/cover.html.haml
+++ b/app/components/invitation/pages/cover.html.haml
@@ -10,27 +10,33 @@
     %h2.absolute.uppercase.text-xs.space-x-1.text-gray-500{ class: "text-[10px] bottom-[120px] tracking-[.1em]" }
       %span= t(".save_the_date")
       %span •
-      %span Alberto & Andrea
+      %span= invitation.wedding.name
 
     - unless invitation.accepted?
-      - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
-      %div{ options.to_h }
-        -# Options before invitation is accepted
-        = form_with(model: invitation_state_transition,
-                    url: invitation_state_transition_url,
-                    method: :post,
-                    builder: ComponentFormBuilder,
-                    data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#greetConfirmedGuest" }) do |form|
-          = form.hidden_field :event, value: "accept"
-          = form.hidden_field :invitation_id, value: @invitation.id
+      - if preview_mode
+        - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
+                                                  class: "!w-[60%] absolute left-1/2 transform -translate-x-1/2 bottom-16" })
+        - options = options.with_stimulus_target("beforeAccept", stimulus_identifier)
+        - options = options.with_stimulus_action("click", stimulus_identifier, "greetConfirmedGuest")
+        = invitation_button_component(**options.to_h)
+      - else
+        - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
+        %div{ options.to_h }
+          -# Options before invitation is accepted
+          = form_with(model: invitation_state_transition,
+                      url: invitation_state_transition_url,
+                      method: :post,
+                      builder: ComponentFormBuilder,
+                      data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#markInvitationAsConfirmed" }) do |form|
+            = form.hidden_field :event, value: "accept"
+            = form.hidden_field :invitation_id, value: @invitation.id
 
-          - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
-                                                    class: "!w-[60%] absolute left-1/2 transform -translate-x-1/2 bottom-16" })
-          - options = options.with_stimulus_target("confirmationButton", stimulus_identifier)
-          = invitation_button_component(**options.to_h)
+            - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
+                                                      class: "absolute left-1/2 transform -translate-x-1/2 bottom-16" })
+            = invitation_button_component(**options.to_h)
 
     -# Options after invitation is accepted
     - options = ::Html::TagAttributes.build({ label: t(".add_to_calendar"), size: :small, scheme: :secondary,
-                                              class: "#{ "hidden opacity-0" unless invitation.accepted? || preview_mode } !w-[60%] bottom-16 absolute margin-auto" })
+                                              class: "#{ "hidden opacity-0" unless invitation.accepted? } bottom-16 absolute margin-auto" })
     - options = options.with_stimulus_target("afterAccept", stimulus_identifier)
     = invitation_button_component(tag: :a, href: calendar_url, **options.to_h)

--- a/app/components/invitation/pages/cover.html.haml
+++ b/app/components/invitation/pages/cover.html.haml
@@ -12,31 +12,5 @@
       %span •
       %span= invitation.wedding.name
 
-    - unless invitation.accepted?
-      - if preview_mode
-        - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
-                                                  class: "!w-[60%] absolute left-1/2 transform -translate-x-1/2 bottom-16" })
-        - options = options.with_stimulus_target("beforeAccept", stimulus_identifier)
-        - options = options.with_stimulus_action("click", stimulus_identifier, "greetConfirmedGuest")
-        = invitation_button_component(**options.to_h)
-      - else
-        - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
-        %div{ options.to_h }
-          -# Options before invitation is accepted
-          = form_with(model: invitation_state_transition,
-                      url: invitation_state_transition_url,
-                      method: :post,
-                      builder: ComponentFormBuilder,
-                      data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#markInvitationAsConfirmed" }) do |form|
-            = form.hidden_field :event, value: "accept"
-            = form.hidden_field :invitation_id, value: @invitation.id
-
-            - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
-                                                      class: "absolute left-1/2 transform -translate-x-1/2 bottom-16" })
-            = invitation_button_component(**options.to_h)
-
-    -# Options after invitation is accepted
-    - options = ::Html::TagAttributes.build({ label: t(".add_to_calendar"), size: :small, scheme: :secondary,
-                                              class: "#{ "hidden opacity-0" unless invitation.accepted? } bottom-16 absolute margin-auto" })
-    - options = options.with_stimulus_target("afterAccept", stimulus_identifier)
-    = invitation_button_component(tag: :a, href: calendar_url, **options.to_h)
+    .absolute.bottom-12.m-auto
+      = render Invitation::Pages::Common::AcceptInvitationButton.new(invitation:, preview_mode:)

--- a/app/components/invitation/pages/cover.rb
+++ b/app/components/invitation/pages/cover.rb
@@ -3,32 +3,10 @@
 class Invitation::Pages::Cover < Invitation::Pages::Page
   def self.page_name = "cover"
 
-  attr_reader :invitation, :invitation_state_transition
+  attr_reader :invitation
 
   def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
     super(preview_mode:, **system_arguments)
-    @preview_mode = preview_mode
-  end
-
-  private
-
-  def calendar_url
-    ::AddToCalendar::URLs.new(
-      # TODO: we need to specify a time for the event
-      start_datetime: invitation.wedding.date.to_time,
-      title: invitation.wedding.name,
-      description: "Party!!!",
-      all_day: true,
-      url: request.original_url,
-      timezone: "Europe/London"
-    ).ical_url
-  end
-
-  def default_content_tag_arguments
-    options = ::Html::TagAttributes.build(super)
-    options = options.with_stimulus_controller(stimulus_identifier)
-    options.to_h
   end
 end

--- a/app/components/invitation/pages/cover.rb
+++ b/app/components/invitation/pages/cover.rb
@@ -7,9 +7,8 @@ class Invitation::Pages::Cover < Invitation::Pages::Page
 
   def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    @preview_mode = preview_mode
     @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
-    super(**system_arguments)
+    super(preview_mode:, **system_arguments)
   end
 
   private

--- a/app/components/invitation/pages/cover.rb
+++ b/app/components/invitation/pages/cover.rb
@@ -9,6 +9,7 @@ class Invitation::Pages::Cover < Invitation::Pages::Page
     @invitation = invitation
     @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
     super(preview_mode:, **system_arguments)
+    @preview_mode = preview_mode
   end
 
   private

--- a/app/components/invitation/pages/cover.yml
+++ b/app/components/invitation/pages/cover.yml
@@ -6,4 +6,4 @@ en:
 es:
   save_the_date: Reserva la fecha
   accept: aceptar invitación
-  add_to_calendar: añadir evento a tu calendario
+  add_to_calendar: añadir evento a calendario

--- a/app/components/invitation/pages/cover_controller.js
+++ b/app/components/invitation/pages/cover_controller.js
@@ -29,11 +29,13 @@ export default class extends Controller {
     'afterAccept'
   ]
 
-  greetConfirmedGuest ({ detail: { fetchResponse } }) {
-    if (fetchResponse.succeeded) {
-      this.#throwConfetti()
-      this.#switchConfirmAndCalendarButtons()
-    }
+  markInvitationAsConfirmed ({ detail: { fetchResponse } }) {
+    if (fetchResponse.succeeded) this.greetConfirmedGuest()
+  }
+
+  greetConfirmedGuest () {
+    this.#throwConfetti()
+    this.#switchConfirmAndCalendarButtons()
   }
 
   async #throwConfetti () {

--- a/app/components/invitation/pages/page.rb
+++ b/app/components/invitation/pages/page.rb
@@ -4,8 +4,8 @@ class Invitation::Pages::Page < Invitation::ApplicationComponent
   attr_reader :preview_mode
 
   def initialize(preview_mode: false, **system_arguments)
-    @preview_mode = preview_mode
     super(**system_arguments)
+    @preview_mode = preview_mode
   end
 
   def self.page_name = raise "Page Component #{name} does not define page_name method"

--- a/app/components/invitation/pages/page.rb
+++ b/app/components/invitation/pages/page.rb
@@ -3,5 +3,10 @@
 class Invitation::Pages::Page < Invitation::ApplicationComponent
   attr_reader :preview_mode
 
+  def initialize(preview_mode: false, **system_arguments)
+    @preview_mode = preview_mode
+    super(**system_arguments)
+  end
+
   def self.page_name = raise "Page Component #{name} does not define page_name method"
 end

--- a/app/components/invitation/pages/schedule.rb
+++ b/app/components/invitation/pages/schedule.rb
@@ -5,9 +5,9 @@ class Invitation::Pages::Schedule < Invitation::Pages::Page
 
   attr_reader :invitation, :schedule, :schedule_decorator
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
     @schedule = Schedule.new(wedding: invitation.wedding, guest: invitation.guests.first)
-    super(**system_arguments)
+    super(preview_mode:, **system_arguments)
   end
 end

--- a/app/components/invitation/pages/travel_guide.rb
+++ b/app/components/invitation/pages/travel_guide.rb
@@ -5,8 +5,8 @@ class Invitation::Pages::TravelGuide < Invitation::Pages::Page
 
   attr_reader :invitation
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    super(**system_arguments)
+    super(preview_mode:, **system_arguments)
   end
 end

--- a/app/components/invitation/pages/welcome.rb
+++ b/app/components/invitation/pages/welcome.rb
@@ -5,8 +5,8 @@ class Invitation::Pages::Welcome < Invitation::Pages::Page
 
   attr_reader :invitation
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    super(**system_arguments)
+    super(preview_mode:, **system_arguments)
   end
 end

--- a/app/components/invitation/pages/welcome_phone.html.haml
+++ b/app/components/invitation/pages/welcome_phone.html.haml
@@ -1,36 +1,27 @@
-= render(Invitation::Layout::PageComponent.new(**content_tag_arguments)) do
-  .h-full.w-full.relative.flex.flex-col.items-center.justify-center.px-6.py-10.text-gray-700
-    %hr.absolute.left-0.my-auto.border-gray-200{ class: "w-[20%]" }
-    %hr.absolute.right-0.my-auto.border-gray-200{ class: "w-[20%]" }
+= render(Invitation::Layout::PageComponent.new) do
+  .relative.h-full.flex.flex-col.items-center.justify-center.px-6.py-10.gap-8.text-gray-500
+    - options = { class: "w-full font-ambrosia text-7xl text-gray-500 text-center" }
+    .flex.flex-col.items-center.justify-center
+      %h1{ options } Alberto
+      %h1{ options.merge(style: "font-size: 40px") } &
+      %h1{ options } Andrea
 
-    %h1.absolute.px-16.m-auto.font-ambrosia.text-8xl.text-gray-500.space-y-4
-      %p{ class: "leading-[0.6]" } 14
-      %p{ class: "leading-[0.6]" } 09
+    .space-y-6
+      %h2.uppercase{ class: "w-[85%] text-[10px] tracking-[.15em]" }= t(".invitation_title_html")
 
-    %h2.absolute.uppercase.text-xs.space-x-1.text-gray-500{ class: "text-[10px] bottom-[120px] tracking-[.1em]" }
-      %span= t(".save_the_date")
-      %span •
-      %span Alberto & Andrea2
+      .flex.flex-row.items-center.justify-start
+        %p.uppercase.text-center.leading-3.mr-6.pr-6.border-r.border-gray-200
+          %span.text-xs= invitation.wedding.date.strftime("%b")
+          %br
+          %span.text-2xl{ class: "tracking-[.05em]" }= invitation.wedding.date.strftime("%d")
+          %br
+          %span.text-sm= invitation.wedding.date.strftime("%Y")
+        %p.uppercase.leading-4{ class: "text-[10px] tracking-[.15em]" }
+          %span.text-gray-700 Ceremony on the 14th at 17:00
+          %br
+          %span Parador de Plasencia
+          %br
+          %span 10600 Plasencia, Cáceres, Spain
+          %p.uppercase.leading-4{ class: "text-[10px] tracking-[.1em]" }
 
-    - unless invitation.accepted?
-      - options = ::Html::TagAttributes.build({}).with_stimulus_target("beforeAccept", stimulus_identifier)
-      %div{ options.to_h }
-        -# Options before invitation is accepted
-        = form_with(model: invitation_state_transition,
-                    url: invitation_state_transition_url,
-                    method: :post,
-                    builder: ComponentFormBuilder,
-                    data: { "turbo-frame" => "", action: "turbo:before-fetch-response->#{stimulus_identifier}#greetConfirmedGuest" }) do |form|
-          = form.hidden_field :event, value: "accept"
-          = form.hidden_field :invitation_id, value: @invitation.id
-
-          - options = ::Html::TagAttributes.build({ label: t(".accept"), size: :small, scheme: :primary,
-                                                    class: "!w-[60%] absolute left-1/2 transform -translate-x-1/2 bottom-16" })
-          - options = options.with_stimulus_target("confirmationButton", stimulus_identifier)
-          = invitation_button_component(**options.to_h)
-
-    -# Options after invitation is accepted
-    - options = ::Html::TagAttributes.build({ label: t(".add_to_calendar"), size: :small, scheme: :secondary,
-                                              class: "#{ "hidden opacity-0" unless invitation.accepted? || preview_mode } !w-[60%] bottom-16 absolute margin-auto" })
-    - options = options.with_stimulus_target("afterAccept", stimulus_identifier)
-    = invitation_button_component(tag: :a, href: calendar_url, **options.to_h)
+    = render Invitation::Pages::Common::AcceptInvitationButton.new(invitation:, preview_mode:)

--- a/app/components/invitation/pages/welcome_phone.rb
+++ b/app/components/invitation/pages/welcome_phone.rb
@@ -7,9 +7,8 @@ class Invitation::Pages::WelcomePhone < Invitation::Pages::Page
 
   def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    @preview_mode = preview_mode
     @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
-    super(**system_arguments)
+    super(preview_mode:, **system_arguments)
   end
 
   private

--- a/app/components/invitation/pages/welcome_phone.rb
+++ b/app/components/invitation/pages/welcome_phone.rb
@@ -7,27 +7,6 @@ class Invitation::Pages::WelcomePhone < Invitation::Pages::Page
 
   def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
-    @invitation_state_transition = InvitationStateTransition.new(event: "accept", invitation:)
     super(preview_mode:, **system_arguments)
-  end
-
-  private
-
-  def calendar_url
-    ::AddToCalendar::URLs.new(
-      # TODO: we need to specify a time for the event
-      start_datetime: invitation.wedding.date.to_time,
-      title: invitation.wedding.name,
-      description: "Party!!!",
-      all_day: true,
-      url: request.original_url,
-      timezone: "Europe/London"
-    ).ical_url
-  end
-
-  def default_content_tag_arguments
-    options = ::Html::TagAttributes.build(super)
-    options = options.with_stimulus_controller(stimulus_identifier)
-    options.to_h
   end
 end

--- a/app/components/invitation/pages/welcome_phone.yml
+++ b/app/components/invitation/pages/welcome_phone.yml
@@ -1,9 +1,7 @@
 en:
   save_the_date: Save the date
-  accept: accept invitation
-  add_to_calendar: add event to calendar
+  invitation_title_html: <span>invite you to join them</span><br><span>in their wedding celebration</span>
 
 es:
   save_the_date: Reserva la fecha
-  accept: aceptar invitación
-  add_to_calendar: añadir evento a tu calendario
+  invitation_title_html: <span>te invitan a asistir</span><br><span>a su ceremonia de boda</span>

--- a/app/components/invitation/show_component.html.haml
+++ b/app/components/invitation/show_component.html.haml
@@ -2,5 +2,5 @@
   -# Background
   %p.font-ambrosia.absolute.w-full.h-full.inline-flex.items-center.justify-center.opacity-10.font-gray-700.text-9xl= t(".salutation")
 
-  = render(Invitation::Envelop.new(invitation:))
-  = render(Invitation::Letter.new(invitation:))
+  = render(Invitation::Envelop.new(invitation:, preview_mode:))
+  = render(Invitation::Letter.new(invitation:, preview_mode:))

--- a/app/components/invitation/show_component.rb
+++ b/app/components/invitation/show_component.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Invitation::ShowComponent < Invitation::ApplicationComponent
-  attr_reader :invitation
+  attr_reader :invitation, :preview_mode
 
-  def initialize(invitation:, **system_arguments)
+  def initialize(invitation:, preview_mode: false, **system_arguments)
     @invitation = invitation
+    @preview_mode = preview_mode
     super(**system_arguments)
   end
 

--- a/app/controllers/invitation/invitation_controller.rb
+++ b/app/controllers/invitation/invitation_controller.rb
@@ -6,7 +6,7 @@ class Invitation::InvitationController < ApplicationController
   # GET /invitation/<invitation-id>
   def show
     @invitation = Invitation.find(params[:id])
-    @preview_mode = params.fetch(:preview_mode) == "true"
+    @preview_mode = params.fetch(:preview_mode, false) == "true"
 
     I18n.locale = @invitation.language
     open_invitation if !@preview_mode && (@invitation.pending? || @invitation.delivered?)

--- a/app/controllers/invitation/invitation_controller.rb
+++ b/app/controllers/invitation/invitation_controller.rb
@@ -6,7 +6,7 @@ class Invitation::InvitationController < ApplicationController
   # GET /invitation/<invitation-id>
   def show
     @invitation = Invitation.find(params[:id])
-    @preview_mode = params.fetch(:preview_mode, false)
+    @preview_mode = params.fetch(:preview_mode) == "true"
 
     I18n.locale = @invitation.language
     open_invitation if !@preview_mode && (@invitation.pending? || @invitation.delivered?)

--- a/app/controllers/invitation/invitation_controller.rb
+++ b/app/controllers/invitation/invitation_controller.rb
@@ -6,13 +6,13 @@ class Invitation::InvitationController < ApplicationController
   # GET /invitation/<invitation-id>
   def show
     @invitation = Invitation.find(params[:id])
+    @preview_mode = params.fetch(:preview_mode, false)
+
     I18n.locale = @invitation.language
-    open_invitation if !preview_mode? && (@invitation.pending? || @invitation.delivered?)
+    open_invitation if !@preview_mode && (@invitation.pending? || @invitation.delivered?)
   end
 
   private
-
-  def preview_mode? = params.fetch(:preview_mode, false)
 
   def open_invitation
     InvitationStateTransition.new(invitation: @invitation, event: :open).save

--- a/app/views/invitation/invitation/show.html.haml
+++ b/app/views/invitation/invitation/show.html.haml
@@ -1,1 +1,1 @@
-= render Invitation::ShowComponent.new(invitation: @invitation)
+= render Invitation::ShowComponent.new(invitation: @invitation, preview_mode: @preview_mode)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,45 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t "hello"
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t("hello") %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   "true": "foo"
+#
+# To learn more, please read the Rails Internationalization guide
+# available at https://guides.rubyonrails.org/i18n.html.
+
+es:
+  date:
+    formats:
+      short_time: "%H:%M"
+      short_month_day: "%b %d"
+      short_date_time: "%H:%M, %d/%m"
+      abbreviated_month: "%b"
+  time:
+    formats:
+      short_time: "%H:%M"
+      short_date_time: "%H:%M, %d/%m"
+  languages:
+    en: "Inglés"
+    es: "Español"

--- a/test/components/previews/invitation/pages/common/accept_invitation_button_preview.rb
+++ b/test/components/previews/invitation/pages/common/accept_invitation_button_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Invitation::Pages::Common::AcceptInvitationButtonPreview < ViewComponent::Preview
+  def default
+    wedding = Invitation::ShowComponentPreview.wedding
+    guest = wedding.guests.first
+    invitation = FactoryBot.build(:invitation, wedding:, guests: [guest])
+    render(Invitation::Pages::Common::AcceptInvitationButton.new(invitation:, preview_mode: true))
+  end
+end


### PR DESCRIPTION
Creates new logic to define `mobile-first` `Invitation` pages. Creates a new page for welcoming phone users and refactors code to keep the layouts as clean as possible.