### PR TITLE
chore: IP access restriction for admin routes

### DIFF
--- a/app/constraints/application_constraint.rb
+++ b/app/constraints/application_constraint.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationConstraint
+  def self.matches?(_request) = raise "Constraint #{name} does not define match condition"
+end

--- a/app/constraints/ip_constraint.rb
+++ b/app/constraints/ip_constraint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class IpConstraint < ApplicationConstraint
+  ALLOWED_IPS = ENV.fetch("ALLOWED_ADMIN_IPS", "").split(",")
+
+  def self.matches?(request)
+    if Rails.env.production?
+      request.ip.in?(ALLOWED_IPS)
+    else
+      true
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,19 +8,21 @@ Rails.application.routes.draw do
 
   mount Lookbook::Engine, at: "/rails/lookbook" if Rails.env.development?
 
-  # Weddings
-  # --------
-  root "weddings#index"
+  constraints(IpConstraint) do
+    # Weddings
+    # --------
+    root "weddings#index"
 
-  resources :weddings, only: %i[index new create show] do
-    resources :events, only: %i[new create edit update destroy]
-    resources :invitations, only: %i[index new create edit update destroy]
-    resources :guests, only: %i[index new edit create update destroy] do
-      # Invitation
-      # ----------
-      get "invitation", to: "invitation/invitation#show"
+    resources :weddings, only: %i[index new create show] do
+      resources :events, only: %i[new create edit update destroy]
+      resources :invitations, only: %i[index new create edit update destroy]
+      resources :guests, only: %i[index new edit create update destroy] do
+        # Invitation
+        # ----------
+        get "invitation", to: "invitation/invitation#show"
+      end
+      resource :schedule, only: %i[show]
     end
-    resource :schedule, only: %i[show]
   end
 
   # Invitations


### PR DESCRIPTION
Adds a route constraint to restrict access to admin panel to a certain range of IPs only, in production mode.