### PR TITLE
fix: Event now persist datetimes in two separated files.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :planned, inclusion: { in: [true, false] }
-  validates :schedule, presence: true
+  validates :start_time, :end_time, presence: true
 
   validates_comparison_of :end_time, greater_than: :start_time
 
@@ -26,7 +26,5 @@ class Event < ApplicationRecord
   # Scopes
   scope :chronological, -> { order(schedule: :asc) }
 
-  def start_time = schedule&.begin
-
-  def end_time = schedule&.end
+  def schedule = start_time..end_time
 end

--- a/app/parameters/event_parameters.rb
+++ b/app/parameters/event_parameters.rb
@@ -14,6 +14,4 @@ class EventParameters < ApplicationParameters
       end
     end
   end
-
-  def excluded_parameters = %i[start_time end_time]
 end

--- a/db/migrate/20240218183222_add_time_range_to_events.rb
+++ b/db/migrate/20240218183222_add_time_range_to_events.rb
@@ -1,0 +1,6 @@
+class AddTimeRangeToEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :events, :start_time, :timestampz
+    add_column :events, :end_time, :timestampz
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_18_173720) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_18_183222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_18_173720) do
     t.timestamptz "created_at", precision: 6, null: false
     t.timestamptz "updated_at", precision: 6, null: false
     t.uuid "place_id"
+    t.timestamptz "start_time"
+    t.timestamptz "end_time"
     t.index ["place_id"], name: "index_events_on_place_id"
     t.index ["wedding_id"], name: "index_events_on_wedding_id"
   end

--- a/lib/factories/events.rb
+++ b/lib/factories/events.rb
@@ -14,7 +14,9 @@ FactoryBot.define do
 
     planned { false }
 
-    schedule { Time.current..rand(10).hours.since(Time.current) }
+    start_time { Time.current }
+    end_time { rand(10).hours.since(Time.current) }
+    schedule { start_time..end_time }
 
     trait :unplanned do
       planned { false }

--- a/test/decorators/event_decorator_test.rb
+++ b/test/decorators/event_decorator_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class EventDecoratorTest < ActiveSupport::TestCase
   setup do
     time_range = Time.zone.local(2021, 1, 1, 12, 0, 0)..Time.zone.local(2021, 1, 1, 13, 0, 0)
-    event = FactoryBot.build(:event, schedule: time_range)
+    event = FactoryBot.build(:event, start_time: time_range.begin, end_time: time_range.end, schedule: time_range)
     @event_decorator = EventDecorator.new(event)
   end
 

--- a/test/decorators/events_group_decorator_test.rb
+++ b/test/decorators/events_group_decorator_test.rb
@@ -12,6 +12,8 @@ class EventsGroupDecoratorTest < ActiveSupport::TestCase
       events: [
         FactoryBot.build(
           :event,
+          start_time: time_range.begin,
+          end_time: time_range.end,
           schedule: time_range,
           place: FactoryBot.build(
             :place,

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -39,7 +39,8 @@ class EventTest < ActiveSupport::TestCase
   test "validates start time is greater than end time" do
     timestamp = Time.zone.local(2023, 11, 11, 11, 11)
 
-    event = FactoryBot.build(:event, start_time: timestamp, end_time: timestamp.ago(1), schedule: timestamp..timestamp.ago(1))
+    event = FactoryBot.build(:event, start_time: timestamp, end_time: timestamp.ago(1),
+                                     schedule: timestamp..timestamp.ago(1))
 
     assert_not event.valid?
     assert event.errors.of_kind?(:end_time, :greater_than)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -20,18 +20,26 @@ class EventTest < ActiveSupport::TestCase
     assert event.errors.of_kind?(:planned, :inclusion)
   end
 
-  test "validates schedule presence" do
+  test "validates start_time presence" do
     event = FactoryBot.build(:event)
-    event.schedule = nil
+    event.start_time = nil
 
     assert_not event.valid?
-    assert event.errors.of_kind?(:schedule, :blank)
+    assert event.errors.of_kind?(:start_time, :blank)
+  end
+
+  test "validates end_time presence" do
+    event = FactoryBot.build(:event)
+    event.end_time = nil
+
+    assert_not event.valid?
+    assert event.errors.of_kind?(:end_time, :blank)
   end
 
   test "validates start time is greater than end time" do
     timestamp = Time.zone.local(2023, 11, 11, 11, 11)
 
-    event = FactoryBot.build(:event, schedule: timestamp..timestamp.ago(1))
+    event = FactoryBot.build(:event, start_time: timestamp, end_time: timestamp.ago(1), schedule: timestamp..timestamp.ago(1))
 
     assert_not event.valid?
     assert event.errors.of_kind?(:end_time, :greater_than)

--- a/test/parameters/event_parameters_test.rb
+++ b/test/parameters/event_parameters_test.rb
@@ -10,7 +10,6 @@ class EventParametersTest < ActiveSupport::TestCase
 
     expected_params = permitted_parameters
                       .merge(schedule: permitted_parameters[:start_time]..permitted_parameters[:end_time])
-                      .except(:start_time, :end_time)
 
     assert_equal expected_params, parsed_params
   end

--- a/test/parameters/guest_parameters_test.rb
+++ b/test/parameters/guest_parameters_test.rb
@@ -11,8 +11,8 @@ class GuestParametersTest < ActiveSupport::TestCase
     schedule = permitted_parameters[:start_time]..permitted_parameters[:end_time]
     expected_parameters = permitted_parameters.merge(
       schedule:,
-      start_time: nil,
-      end_time: nil
+      start_time: permitted_parameters[:start_time],
+      end_time: permitted_parameters[:end_time]
     ).compact_blank
 
     assert_equal expected_parameters, parsed_params


### PR DESCRIPTION
Range field was not persisting the timestampz, only the range of dates. Thus we were not able to display the exact times of the events.

I added two new timestamp fields to display the proper times. This makes now the schedule field redundant, and should be removed in a future PR.